### PR TITLE
fix(native): resolve Workflow deserialization and stub loading in GraalVM

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,24 +33,22 @@ subprojects {
         "testRuntimeOnly"("org.junit.platform:junit-platform-launcher")
     }
 
+    val jvm25Args = listOf(
+        "--enable-native-access=ALL-UNNAMED",
+        "--add-opens", "java.base/java.lang=ALL-UNNAMED"
+    )
+
     tasks.withType<JavaCompile> {
         options.encoding = "UTF-8"
-        // Retain method parameter names in bytecode
         options.compilerArgs.add("-parameters")
     }
 
-    // Java 24+ JVM args required across all execution modes:
-    //   --enable-native-access: Foreign Function & Memory API (Project Panama)
-    //   --add-opens java.base/java.lang: Vert.x / JBoss Threads thread-local reset
-    // See: https://github.com/quarkusio/quarkus/discussions/51041
-    val jvm24Args = listOf("--enable-native-access=ALL-UNNAMED", "--add-opens", "java.base/java.lang=ALL-UNNAMED")
-
     tasks.withType<JavaExec> {
-        jvmArgs(jvm24Args)
+        jvmArgs(jvm25Args)
     }
 
     tasks.test {
-        jvmArgs(jvm24Args)
+        jvmArgs(jvm25Args)
         useJUnitPlatform()
     }
 

--- a/docs/developer-guide-core.md
+++ b/docs/developer-guide-core.md
@@ -898,6 +898,8 @@ HensuFactory.builder()
 
 ### Jackson Serialization Pattern
 
+**`hensu-core` must contain zero Jackson annotations.** No `@JsonDeserialize`, `@JsonProperty`, `@JsonTypeInfo`, or any Jackson import belongs here. All serialization metadata lives in `hensu-serialization`; all native-image reflection registrations live in `hensu-server`. This keeps the core framework-agnostic.
+
 The `hensu-serialization` module uses explicit `SimpleModule` registrations instead of Jackson's reflective annotation processing:
 
 ```java
@@ -914,6 +916,8 @@ When adding new serializable types:
 2. Register them in `HensuJacksonModule`
 3. Do **not** rely on `@JsonTypeInfo` with class names — GraalVM cannot resolve them at runtime
 4. Use a `"type"` discriminator field with an explicit `switch` in the deserializer
+
+> **See also**: [hensu-serialization Developer Guide](developer-guide-serialization.md) for the full Jackson contract — mixin/builder pattern, `treeToValue` rules, and how to add new types safely.
 
 ### Writing Native-Image-Safe Adapters
 

--- a/docs/developer-guide-serialization.md
+++ b/docs/developer-guide-serialization.md
@@ -1,0 +1,313 @@
+# Hensu™ Serialization Developer Guide
+
+This guide covers the design, rules, and extension patterns for the `hensu-serialization` module.
+
+## Table of Contents
+
+- [Design Philosophy](#design-philosophy)
+- [Module Architecture](#module-architecture)
+- [HensuJacksonModule](#hensujacksonmodule)
+  - [Mixin/Builder Pattern](#mixinbuilder-pattern)
+  - [Custom Deserializer Pattern](#custom-deserializer-pattern)
+- [The `treeToValue` Rule](#the-treetovalue-rule)
+- [Adding a New Serializable Type](#adding-a-new-serializable-type)
+  - [Sealed Hierarchy (polymorphic)](#sealed-hierarchy-polymorphic)
+  - [Builder-pattern domain object](#builder-pattern-domain-object)
+- [Native Image Implications](#native-image-implications)
+- [Key Classes Reference](#key-classes-reference)
+
+---
+
+## Design Philosophy
+
+`hensu-serialization` exists so that `hensu-core` stays framework- and library-agnostic:
+
+- **`hensu-core`** — zero Jackson imports. Domain objects are plain Java records and builder classes.
+- **`hensu-serialization`** — owns all Jackson `Module`, `JsonSerializer`, `JsonDeserializer`, and mixin definitions.
+- **`hensu-server`** — owns all GraalVM reflection registrations needed by the serialization module.
+
+This three-layer boundary means a CLI or embedded deployment can swap in a different serialization library without touching the core engine. It also means Quarkus native-image metadata never pollutes the domain model.
+
+---
+
+## Module Architecture
+
+```
++——————————————————————————————————————————————————————————————————+
+│                       hensu-serialization                        │
+│                                                                  │
+│  WorkflowSerializer                                              │
+│    └── creates ObjectMapper + registers HensuJacksonModule       │
+│                                                                  │
+│  HensuJacksonModule (SimpleModule)                               │
+│    │                                                             │
+│    ├── addSerializer / addDeserializer (polymorphic hierarchies) │
+│    │     Node, TransitionRule, Action                            │
+│    │                                                             │
+│    └── setMixInAnnotations (builder-pattern domain objects)      │
+│          Workflow, AgentConfig, ExecutionStep,                   │
+│          NodeResult, BacktrackEvent, ExecutionHistory            │
+│                                                                  │
+│  mixin/                                                          │
+│    *Mixin.java       — carries @JsonDeserialize on the type      │
+│    *BuilderMixin.java — carries @JsonPOJOBuilder on the builder  │
++——————————————————————————————————————————————————————————————————+
+          │ depends on                        │ reflection info
+          V                                   V
++——————————————+              +——————————————————————————————+
+│  hensu-core  │              │         hensu-server         │
+│  (zero       │              │  NativeImageConfig           │
+│   Jackson)   │              │  @RegisterForReflection(     │
++——————————————+              │    Workflow.Builder.class,   │
+                              │    AgentConfig.Builder.class,│
+                              │    ...)                      │
+                              +——————————————————————————————+
+```
+
+---
+
+## HensuJacksonModule
+
+`HensuJacksonModule` is registered once in `WorkflowSerializer.createMapper()`. It uses two distinct patterns depending on the type's structure.
+
+### Mixin/Builder Pattern
+
+Used for **immutable domain objects** that are constructed via an inner `Builder` class with a private constructor. Jackson cannot call `new Builder()` directly without reflection, so a mixin connects the dots at build time.
+
+**How it works:**
+
+```
+WorkflowMixin              WorkflowBuilderMixin
+@JsonDeserialize           @JsonPOJOBuilder(
+  (builder =                 withPrefix = "",
+   Workflow.Builder.class)    buildMethodName = "build")
+
+     │ applied to                   │ applied to
+     V                              V
+Workflow.class             Workflow.Builder.class
+```
+
+At deserialization time Jackson:
+1. Reads `WorkflowMixin` → finds `@JsonDeserialize(builder = Workflow.Builder.class)`
+2. Instantiates `Workflow.Builder` (via **reflection** — private constructor)
+3. Reads `WorkflowBuilderMixin` → finds `@JsonPOJOBuilder(withPrefix = "", buildMethodName = "build")`
+4. Calls each setter by name (via **reflection**)
+5. Calls `builder.build()` (via **reflection**)
+
+Because `hensu-core` builders have `private` constructors, all three reflection calls require native-image registration. This is handled in `NativeImageConfig` in `hensu-server` — never in `hensu-core` itself.
+
+**Registration in `HensuJacksonModule`:**
+
+```java
+context.setMixInAnnotations(Workflow.class, WorkflowMixin.class);
+context.setMixInAnnotations(Workflow.Builder.class, WorkflowBuilderMixin.class);
+```
+
+**Why `quarkus-jackson` cannot help:** The Quarkus Jackson extension only registers classes that carry Jackson annotations *directly*. `Workflow` has none — the annotations live on the mixin class. The mixin mapping is a runtime event inside `setupModule()`, invisible to Quarkus build-time scanning.
+
+### Custom Deserializer Pattern
+
+Used for **sealed polymorphic hierarchies** where a `"type"` discriminator field determines the concrete subtype. Custom `StdDeserializer` subclasses read the JSON tree manually.
+
+| Type             | Serializer                 | Deserializer                 |
+|------------------|----------------------------|------------------------------|
+| `Node`           | `NodeSerializer`           | `NodeDeserializer`           |
+| `TransitionRule` | `TransitionRuleSerializer` | `TransitionRuleDeserializer` |
+| `Action`         | `ActionSerializer`         | `ActionDeserializer`         |
+
+Each deserializer follows the same skeleton:
+
+```java
+@Override
+public Node deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+    ObjectMapper mapper = (ObjectMapper) p.getCodec();
+    JsonNode root = mapper.readTree(p);          // 1. read the whole tree
+    String type = root.get("type").asText();     // 2. read discriminator
+    return switch (type) {                        // 3. branch on type
+        case "standard" -> deserializeStandard(mapper, root);
+        // ...
+        default -> throw new IOException("Unknown type: " + type);
+    };
+}
+```
+
+Nested primitive/enum/string fields are extracted directly from `JsonNode`. See the `treeToValue` rule below for how to handle nested complex types.
+
+---
+
+## The `treeToValue` Rule
+
+`mapper.treeToValue(jsonNode, SomeClass.class)` delegates deserialization of a subtree to Jackson's standard POJO machinery. This works in JVM mode but **requires reflection registration** in GraalVM native image, because Jackson calls the constructor and field setters reflectively.
+
+### Rule
+
+> Custom deserializers in `hensu-serialization` must **not** call `treeToValue` for simple `hensu-core` records. Extract fields manually from `JsonNode` instead.
+
+**Simple** means: all fields are primitives, `String`, enums, or nullable wrappers of the above.
+
+**Correct — manual extraction (no reflection):**
+
+```java
+// ReviewConfig(ReviewMode mode, boolean allowBacktrack, boolean allowEdit)
+if (root.has("reviewConfig")) {
+    JsonNode rc = root.get("reviewConfig");
+    b.reviewConfig(new ReviewConfig(
+            ReviewMode.valueOf(rc.get("mode").asText()),
+            rc.get("allowBacktrack").asBoolean(),
+            rc.get("allowEdit").asBoolean()));
+}
+```
+
+**Wrong — treeToValue (reflection required):**
+
+```java
+if (root.has("reviewConfig")) {
+    b.reviewConfig(mapper.treeToValue(root.get("reviewConfig"), ReviewConfig.class));
+}
+```
+
+### When `treeToValue` is acceptable
+
+If the target class contains a `java.time.Duration`, deeply nested types, or other fields where manual extraction would be error-prone and brittle, `treeToValue` is acceptable. The class must then be registered in `NativeImageConfig` in `hensu-server`.
+
+Current exceptions (registered in `NativeImageConfig`):
+
+| Class             | Reason                                                  |
+|-------------------|---------------------------------------------------------|
+| `PlanningConfig`  | Contains `PlanConstraints` (itself contains `Duration`) |
+| `PlanConstraints` | Contains `java.time.Duration`                           |
+| `Plan`            | Contains `List<PlannedStep>` and `PlanConstraints`      |
+| `PlannedStep`     | Contains `Map<String, Object>` and `StepStatus` enum    |
+
+### Checklist before using `treeToValue`
+
+- [ ] Does the class contain a `Duration` or other JDK complex type? → register it
+- [ ] Are all fields primitives/strings/enums? → extract manually instead
+- [ ] Does the class already have a custom deserializer? → use it via `mapper` (safe)
+- [ ] Added to `NativeImageConfig` if registering? → cross-check both places
+
+---
+
+## Adding a New Serializable Type
+
+### Sealed Hierarchy (polymorphic)
+
+For a new sealed interface like `MyEvent` with subtypes:
+
+1. **Create serializer** — write a `"type"` field + subtype-specific fields:
+
+```java
+class MyEventSerializer extends StdSerializer<MyEvent> {
+    @Override
+    public void serialize(MyEvent value, JsonGenerator gen, SerializerProvider p)
+            throws IOException {
+        gen.writeStartObject();
+        switch (value) {
+            case MyEvent.TypeA a -> {
+                gen.writeStringField("type", "typeA");
+                gen.writeStringField("field", a.field());
+            }
+            case MyEvent.TypeB b -> {
+                gen.writeStringField("type", "typeB");
+                gen.writeNumberField("count", b.count());
+            }
+        }
+        gen.writeEndObject();
+    }
+}
+```
+
+2. **Create deserializer** — read `"type"`, extract fields manually:
+
+```java
+class MyEventDeserializer extends StdDeserializer<MyEvent> {
+    @Override
+    public MyEvent deserialize(JsonParser p, DeserializationContext ctxt)
+            throws IOException {
+        ObjectMapper mapper = (ObjectMapper) p.getCodec();
+        JsonNode root = mapper.readTree(p);
+        return switch (root.get("type").asText()) {
+            case "typeA" -> new MyEvent.TypeA(root.get("field").asText());
+            case "typeB" -> new MyEvent.TypeB(root.get("count").asInt());
+            default -> throw new IOException("Unknown MyEvent type");
+        };
+    }
+}
+```
+
+3. **Register in `HensuJacksonModule`:**
+
+```java
+addSerializer(MyEvent.class, new MyEventSerializer());
+addDeserializer(MyEvent.class, new MyEventDeserializer());
+```
+
+No reflection registration needed — the deserializer constructs subtypes directly.
+
+### Builder-pattern domain object
+
+For a new immutable class like `MyConfig` with a builder:
+
+1. **Create mixin pair:**
+
+```java
+// MyConfigMixin.java
+@JsonDeserialize(builder = MyConfig.Builder.class)
+public abstract class MyConfigMixin {}
+
+// MyConfigBuilderMixin.java
+@JsonPOJOBuilder(withPrefix = "", buildMethodName = "build")
+public abstract class MyConfigBuilderMixin {}
+```
+
+2. **Register in `HensuJacksonModule`:**
+
+```java
+context.setMixInAnnotations(MyConfig.class, MyConfigMixin.class);
+context.setMixInAnnotations(MyConfig.Builder.class, MyConfigBuilderMixin.class);
+```
+
+3. **Register for reflection in `NativeImageConfig`** (in `hensu-server`):
+
+```java
+@RegisterForReflection(
+        targets = {
+            // ... existing entries ...
+            MyConfig.class,
+            MyConfig.Builder.class
+        })
+public class NativeImageConfig {}
+```
+
+All three steps are required. Missing step 3 causes a silent runtime failure in native image: Jackson finds the builder class but cannot invoke the private constructor or `build()` method.
+
+---
+
+## Native Image Implications
+
+| What                                          | Where to fix                                                |
+|-----------------------------------------------|-------------------------------------------------------------|
+| Builder's private constructor not found       | Add class to `NativeImageConfig` in server                  |
+| `build()` method not found at runtime         | Add class to `NativeImageConfig` in server                  |
+| `treeToValue` target fails with NPE/exception | Prefer manual extraction; if not feasible, register         |
+| New serializable type breaks native build     | Check the checklist in this guide, add mixin + registration |
+
+The root rule: **`hensu-core` owns no serialization metadata. `hensu-serialization` owns the Jackson configuration. `hensu-server` owns the native-image registrations.** This three-way split keeps each module independently deployable and testable.
+
+---
+
+## Key Classes Reference
+
+| Class                                                     | Description                                                       |
+|-----------------------------------------------------------|-------------------------------------------------------------------|
+| `WorkflowSerializer`                                      | Factory — creates the configured `ObjectMapper`                   |
+| `HensuJacksonModule`                                      | `SimpleModule` — registers all serializers, deserializers, mixins |
+| `NodeSerializer` / `NodeDeserializer`                     | Polymorphic `Node` hierarchy (discriminator: `nodeType`)          |
+| `TransitionRuleSerializer` / `TransitionRuleDeserializer` | Polymorphic `TransitionRule` (discriminator: `type`)              |
+| `ActionSerializer` / `ActionDeserializer`                 | Polymorphic `Action` (discriminator: `type`)                      |
+| `mixin/*Mixin.java`                                       | `@JsonDeserialize` bridge for builder-pattern types               |
+| `mixin/*BuilderMixin.java`                                | `@JsonPOJOBuilder` configuration for builder inner classes        |
+
+> **See also**:
+> - [hensu-core Developer Guide — GraalVM](developer-guide-core.md#graalvm-native-image-constraints) for foundational native-image rules
+> - [hensu-server Developer Guide — NativeImageConfig](developer-guide-server.md#nativeimageconfig--jackson-reflection-registration) for registration patterns and the resource bundling rule

--- a/hensu-serialization/src/main/java/io/hensu/serialization/ActionDeserializer.java
+++ b/hensu-serialization/src/main/java/io/hensu/serialization/ActionDeserializer.java
@@ -23,7 +23,7 @@ class ActionDeserializer extends StdDeserializer<Action> {
     }
 
     @Override
-    public Action deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+    public Action deserialize(JsonParser p, DeserializationContext ctx) throws IOException {
         ObjectMapper mapper = (ObjectMapper) p.getCodec();
         JsonNode root = mapper.readTree(p);
 

--- a/hensu-serialization/src/main/java/io/hensu/serialization/TransitionRuleDeserializer.java
+++ b/hensu-serialization/src/main/java/io/hensu/serialization/TransitionRuleDeserializer.java
@@ -1,18 +1,23 @@
 package io.hensu.serialization;
 
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import io.hensu.core.rubric.model.ComparisonOperator;
+import io.hensu.core.rubric.model.DoubleRange;
 import io.hensu.core.rubric.model.ScoreCondition;
 import io.hensu.core.workflow.transition.*;
 import java.io.IOException;
 import java.io.Serial;
+import java.util.ArrayList;
 import java.util.List;
 
 /// Deserializes `TransitionRule` variants based on the `type` discriminator field.
+///
+/// All nested domain types (`ScoreCondition`, `DoubleRange`) are extracted manually from the
+/// `JsonNode` tree to avoid POJO reflection, keeping this deserializer native-image safe.
 ///
 /// @see TransitionRuleSerializer for the inverse operation
 class TransitionRuleDeserializer extends StdDeserializer<TransitionRule> {
@@ -24,8 +29,7 @@ class TransitionRuleDeserializer extends StdDeserializer<TransitionRule> {
     }
 
     @Override
-    public TransitionRule deserialize(JsonParser p, DeserializationContext ctxt)
-            throws IOException {
+    public TransitionRule deserialize(JsonParser p, DeserializationContext ctx) throws IOException {
         ObjectMapper mapper = (ObjectMapper) p.getCodec();
         JsonNode root = mapper.readTree(p);
 
@@ -37,13 +41,26 @@ class TransitionRuleDeserializer extends StdDeserializer<TransitionRule> {
                     new FailureTransition(
                             root.get("retryCount").asInt(), root.get("targetNode").asText());
             case "always" -> new AlwaysTransition();
-            case "score" ->
-                    new ScoreTransition(
-                            mapper.treeToValue(
-                                    root.get("conditions"),
-                                    mapper.constructType(
-                                            new TypeReference<
-                                                    List<ScoreCondition>>() {}.getType())));
+            case "score" -> {
+                List<ScoreCondition> conditions = new ArrayList<>();
+                for (JsonNode c : root.get("conditions")) {
+                    ComparisonOperator op = ComparisonOperator.valueOf(c.get("operator").asText());
+                    Double value =
+                            c.has("value") && !c.get("value").isNull()
+                                    ? c.get("value").doubleValue()
+                                    : null;
+                    DoubleRange range = null;
+                    if (c.has("range") && !c.get("range").isNull()) {
+                        JsonNode r = c.get("range");
+                        range =
+                                new DoubleRange(
+                                        r.get("start").doubleValue(), r.get("end").doubleValue());
+                    }
+                    conditions.add(
+                            new ScoreCondition(op, value, range, c.get("targetNode").asText()));
+                }
+                yield new ScoreTransition(conditions);
+            }
             case "rubricFail" -> new RubricFailTransition(_ -> null);
             default -> throw new IOException("Unknown TransitionRule type: " + type);
         };

--- a/hensu-serialization/src/main/java/io/hensu/serialization/mixin/AgentConfigBuilderMixin.java
+++ b/hensu-serialization/src/main/java/io/hensu/serialization/mixin/AgentConfigBuilderMixin.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 /// Mixin for `AgentConfig.Builder` to handle the naming mismatch:
 /// getter `isMaintainContext()` serializes as `"maintainContext"`,
 /// but the builder setter is `maintainContext(boolean)`.
-@JsonPOJOBuilder(withPrefix = "", buildMethodName = "build")
+@JsonPOJOBuilder(withPrefix = "")
 public abstract class AgentConfigBuilderMixin {
 
     @JsonProperty("maintainContext")

--- a/hensu-serialization/src/main/java/io/hensu/serialization/mixin/WorkflowBuilderMixin.java
+++ b/hensu-serialization/src/main/java/io/hensu/serialization/mixin/WorkflowBuilderMixin.java
@@ -2,5 +2,5 @@ package io.hensu.serialization.mixin;
 
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
-@JsonPOJOBuilder(withPrefix = "", buildMethodName = "build")
+@JsonPOJOBuilder(withPrefix = "")
 public abstract class WorkflowBuilderMixin {}

--- a/hensu-server/README.md
+++ b/hensu-server/README.md
@@ -344,6 +344,7 @@ hensu-server/
 │   │   └── ConstraintViolationExceptionMapper.java  # Global 400 error mapper
 │   ├── config/                            # CDI configuration
 │   │   ├── HensuEnvironmentProducer.java  # HensuFactory → HensuEnvironment
+│   │   ├── NativeImageConfig.java         # GraalVM @RegisterForReflection (Jackson mixin targets)
 │   │   ├── ServerBootstrap.java           # Startup registrations
 │   │   └── ServerConfiguration.java       # CDI delegation + server beans
 │   ├── executor/                          # Planning-aware execution

--- a/hensu-server/src/main/java/io/hensu/server/config/NativeImageConfig.java
+++ b/hensu-server/src/main/java/io/hensu/server/config/NativeImageConfig.java
@@ -1,0 +1,65 @@
+package io.hensu.server.config;
+
+import io.hensu.core.agent.AgentConfig;
+import io.hensu.core.execution.executor.NodeResult;
+import io.hensu.core.execution.result.BacktrackEvent;
+import io.hensu.core.execution.result.ExecutionHistory;
+import io.hensu.core.execution.result.ExecutionStep;
+import io.hensu.core.plan.Plan;
+import io.hensu.core.plan.PlanConstraints;
+import io.hensu.core.plan.PlannedStep;
+import io.hensu.core.plan.PlanningConfig;
+import io.hensu.core.workflow.Workflow;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/// GraalVM native image reflection registrations for `hensu-core` domain model classes.
+///
+/// Two patterns require explicit registration:
+///
+/// ### 1. Jackson `@JsonPOJOBuilder` mixin pattern
+/// {@link io.hensu.serialization.HensuJacksonModule} maps each of these types to a builder mixin.
+/// At runtime, Jackson must reflectively instantiate the builder (private constructor), call each
+/// setter, and invoke `build()`. GraalVM cannot trace these call sites statically.
+///
+/// - `Workflow` / `Workflow.Builder`
+/// - `AgentConfig` / `AgentConfig.Builder`
+/// - `ExecutionStep` / `ExecutionStep.Builder`
+/// - `NodeResult` / `NodeResult.Builder`
+/// - `BacktrackEvent` / `BacktrackEvent.Builder`
+/// - `ExecutionHistory`
+///
+/// ### 2. `treeToValue` delegation in custom deserializers
+/// `io.hensu.serialization.NodeDeserializer` delegates `PlanningConfig` and `Plan`
+/// deserialization to `mapper.treeToValue()` because their nested `Duration` / `PlannedStep`
+/// fields make manual `JsonNode` extraction error-prone. These types must be registered so
+/// Jackson's POJO reflection can reach their fields at runtime.
+///
+/// Simple nested types (`ReviewConfig`, `ConsensusConfig`, `Branch`, `ScoreCondition`,
+/// `DoubleRange`) are extracted manually in their respective deserializers and do **not** need
+/// registration here.
+///
+/// @implNote No Quarkus annotations are placed on `hensu-core` types. All native image metadata
+/// lives in `hensu-server`, keeping the core module dependency-free.
+/// @see io.hensu.serialization.HensuJacksonModule for the mixin registrations and
+///     `treeToValue` delegation sites
+@RegisterForReflection(
+        targets = {
+            // --- Mixin/builder pattern ---
+            Workflow.class,
+            Workflow.Builder.class,
+            AgentConfig.class,
+            AgentConfig.Builder.class,
+            ExecutionStep.class,
+            ExecutionStep.Builder.class,
+            NodeResult.class,
+            NodeResult.Builder.class,
+            BacktrackEvent.class,
+            BacktrackEvent.Builder.class,
+            ExecutionHistory.class,
+            // --- treeToValue delegation (Duration nesting) ---
+            PlanningConfig.class,
+            PlanConstraints.class,
+            Plan.class,
+            PlannedStep.class
+        })
+public class NativeImageConfig {}

--- a/hensu-server/src/main/resources/application.properties
+++ b/hensu-server/src/main/resources/application.properties
@@ -26,6 +26,12 @@ quarkus.http.host=0.0.0.0
 
 # Application
 quarkus.application.name=hensu-server
+hensu.stub.enabled=false
+
+# Native image: bundle stub response files so getResourceAsStream works at runtime.
+# StubResponseRegistry builds paths dynamically (/stubs/{scenario}/{key}.txt),
+# which GraalVM cannot trace statically - explicit inclusion is required.
+quarkus.native.resources.includes=stubs/**
 
 # Logging
 quarkus.log.level=INFO


### PR DESCRIPTION
- Register Workflow and Builder for reflection via NativeImageConfig
- Replace treeToValue() with manual node extraction for records to assist GraalVM static analysis
- Include stub resources in the native binary via quarkus.native.resources.includes
- Document native serialization contracts in developer-guide-serialization.md

Fixes: #21