### PR TITLE
feat(server): formalize execution output delivery and Loom compliance

### DIFF
--- a/hensu-server/src/test/java/io/hensu/server/api/McpGatewayResourceTest.java
+++ b/hensu-server/src/test/java/io/hensu/server/api/McpGatewayResourceTest.java
@@ -30,17 +30,6 @@ class McpGatewayResourceTest {
     class Connect {
 
         @Test
-        void shouldCreateSessionForValidClientId() {
-            Multi<String> mockStream = Multi.createFrom().items("{\"test\":\"ping\"}");
-            when(sessionManager.createSession("client-1")).thenReturn(mockStream);
-
-            Multi<String> result = resource.connect("client-1");
-
-            assertThat(result).isNotNull();
-            verify(sessionManager).createSession("client-1");
-        }
-
-        @Test
         void shouldStreamEventsFromSessionManager() {
             Multi<String> mockStream =
                     Multi.createFrom()


### PR DESCRIPTION
- Introduce GET /executions/{id}/result endpoint to expose consolidated workflow output
- Align ExecutionCompleted event schema with the unified result contract
- Migrate ExecutionEventBroadcaster from ThreadLocal to ScopedValue per Java 25 standards