### PR TITLE
feat(core): implement AgentOutputValidator and integrate with executi…

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,14 +246,15 @@ custom instructions or CLAUDE.md files.
 Hensu is designed for Zero-Trust environments. The server is a **pure orchestrator** — it never executes
 user-supplied code.
 
-| Principle              | Implementation                                                                                                                                                          |
-|:-----------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **No Local Execution** | The server has no shell, no `eval`, no script runner. All side effects route through MCP to tenant clients.                                                             |
-| **Tenant Isolation**   | Every execution runs inside a Java `ScopedValue` boundary. No data leaks between concurrent workflows.                                                                  |
-| **No Inbound Ports**   | The Split-Pipe transport means tenant clients connect *outbound* via SSE. No firewall rules required.                                                                   |
-| **Stateless Server**   | Workflow state is externalized to pluggable repositories. The server can be killed and restarted at any time.                                                           |
-| **Input Validation**   | All API inputs are validated at the boundary. Identifiers are restricted to a safe character set; free-text fields are sanitized to reject control character injection. |
-| **Native Binary**      | GraalVM native image eliminates classpath scanning, reflection, and dynamic class loading attack surfaces.                                                              |
+| Principle              | Implementation                                                                                                                                                                                                  |
+|:-----------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **No Local Execution** | The server has no shell, no `eval`, no script runner. All side effects route through MCP to tenant clients.                                                                                                     |
+| **Tenant Isolation**   | Every execution runs inside a Java `ScopedValue` boundary. No data leaks between concurrent workflows.                                                                                                          |
+| **No Inbound Ports**   | The Split-Pipe transport means tenant clients connect *outbound* via SSE. No firewall rules required.                                                                                                           |
+| **Stateless Server**   | Workflow state is externalized to pluggable repositories. The server can be killed and restarted at any time.                                                                                                   |
+| **Input Validation**   | All API inputs are validated at the boundary. Identifiers are restricted to a safe character set; free-text fields are sanitized to reject control character injection.                                         |
+| **Output Validation**  | LLM-generated node outputs are validated before entering workflow state. ASCII control characters, Unicode manipulation characters (RTL overrides, zero-width chars, BOM), and oversized payloads are rejected. |
+| **Native Binary**      | GraalVM native image eliminates classpath scanning, reflection, and dynamic class loading attack surfaces.                                                                                                      |
 
 
 ## Legal

--- a/hensu-core/README.md
+++ b/hensu-core/README.md
@@ -16,6 +16,7 @@ The `hensu-core` module is the execution engine at the heart of Hensu. It provid
 - **Template Resolution** — `{variable}` placeholder substitution in prompts
 - **State Snapshots** — Serializable execution state for persistence and time-travel debugging
 - **Generic Nodes** — Extensible node types for custom workflow operations
+- **Agentic Output Validation** — Defense-in-depth safety checks applied to all LLM-generated node outputs before they enter workflow state (ASCII control chars, Unicode manipulation chars, payload size)
 
 ## Architecture
 
@@ -232,7 +233,7 @@ hensu-core/src/main/java/io/hensu/core/
 │   │   ├── PostNodeExecutionProcessor.java      # Post-execution processor interface
 │   │   ├── ProcessorContext.java                # Per-iteration context (node + result + state)
 │   │   ├── ProcessorPipeline.java               # Orchestrates pre/post processor chains
-│   │   ├── OutputExtractionPostProcessor.java   # Stores node output in state context
+│   │   ├── OutputExtractionPostProcessor.java   # Validates then stores node output in state context
 │   │   ├── HistoryPostProcessor.java            # Records execution steps for audit
 │   │   ├── ReviewPostProcessor.java             # Human-in-the-loop review checkpoints
 │   │   ├── RubricPostProcessor.java             # Quality evaluation + auto-backtrack
@@ -278,6 +279,9 @@ hensu-core/src/main/java/io/hensu/core/
 │   └── PlanEvent.java             # Plan lifecycle events
 ├── review/                        # Human review support
 ├── template/                      # {variable} placeholder resolution
+├── util/
+│   ├── AgentOutputValidator.java  # LLM output safety checks (control chars, Unicode tricks, size)
+│   └── JsonUtil.java              # Dependency-free JSON extraction utilities
 └── state/                         # Execution state and persistence
     ├── HensuState.java            # Mutable runtime state during execution
     ├── HensuSnapshot.java         # Immutable checkpoint record for persistence

--- a/hensu-core/src/main/java/io/hensu/core/execution/pipeline/OutputExtractionPostProcessor.java
+++ b/hensu-core/src/main/java/io/hensu/core/execution/pipeline/OutputExtractionPostProcessor.java
@@ -1,6 +1,8 @@
 package io.hensu.core.execution.pipeline;
 
 import io.hensu.core.execution.result.ExecutionResult;
+import io.hensu.core.state.HensuState;
+import io.hensu.core.util.AgentOutputValidator;
 import io.hensu.core.util.JsonUtil;
 import io.hensu.core.workflow.node.StandardNode;
 import java.util.Optional;
@@ -8,18 +10,27 @@ import java.util.logging.Logger;
 
 /// Extracts node execution output into the workflow state context.
 ///
-/// Performs two operations when a node produces non-null output:
-/// 1. Stores the raw output string keyed by node ID in the context map
-/// 2. For {@link StandardNode}s with `outputParams`, parses JSON output
+/// Performs three operations when a node produces non-null output:
+/// 1. Validates the output for safety violations (dangerous chars, Unicode tricks, size)
+/// 2. Stores the raw output string keyed by node ID in the context map
+/// 3. For {@link StandardNode}s with `outputParams`, parses JSON output
 ///    and extracts named parameters into the context map
 ///
 /// ### Contracts
 /// - **Precondition**: `context.result()` is non-null (post-execution pipeline)
-/// - **Postcondition**: Always returns empty (never short-circuits)
-/// - **Side effects**: Mutates `context.state().getContext()` map
+/// - **Postcondition**: Returns empty on success; returns `Failure` if output fails validation
+/// - **Side effects**: Mutates `context.state().getContext()` map only on success
+///
+/// ### Validation
+/// LLM-generated outputs are non-deterministic and treated as untrusted. Before storing
+/// output in the context, this processor rejects:
+/// - Outputs containing dangerous ASCII control characters
+/// - Outputs containing Unicode manipulation characters (RTL overrides, zero-width chars, BOM)
+/// - Outputs exceeding {@link AgentOutputValidator#MAX_LLM_OUTPUT_BYTES} (4 MB)
 ///
 /// @implNote Stateless. Safe to reuse across loop iterations.
 ///
+/// @see AgentOutputValidator for validation predicates
 /// @see JsonUtil#extractOutputParams for JSON parameter extraction
 public final class OutputExtractionPostProcessor implements PostNodeExecutionProcessor {
 
@@ -32,19 +43,41 @@ public final class OutputExtractionPostProcessor implements PostNodeExecutionPro
         var state = context.state();
         var node = context.currentNode();
 
-        if (result.getOutput() != null) {
-            state.getContext().put(node.getId(), result.getOutput().toString());
+        if (result.getOutput() == null) {
+            return Optional.empty();
+        }
 
-            if (node instanceof StandardNode standardNode
-                    && !standardNode.getOutputParams().isEmpty()) {
-                JsonUtil.extractOutputParams(
-                        standardNode.getOutputParams(),
-                        result.getOutput().toString(),
-                        state.getContext(),
-                        logger);
-            }
+        String output = result.getOutput().toString();
+
+        if (AgentOutputValidator.containsDangerousChars(output)) {
+            return rejectOutput(state, node.getId(), "contains illegal control characters");
+        }
+
+        if (AgentOutputValidator.containsUnicodeTricks(output)) {
+            return rejectOutput(state, node.getId(), "contains Unicode manipulation characters");
+        }
+
+        if (AgentOutputValidator.exceedsSizeLimit(
+                output, AgentOutputValidator.MAX_LLM_OUTPUT_BYTES)) {
+            return rejectOutput(state, node.getId(), "exceeds maximum allowed size");
+        }
+
+        state.getContext().put(node.getId(), output);
+
+        if (node instanceof StandardNode standardNode
+                && !standardNode.getOutputParams().isEmpty()) {
+            JsonUtil.extractOutputParams(
+                    standardNode.getOutputParams(), output, state.getContext(), logger);
         }
 
         return Optional.empty();
+    }
+
+    private Optional<ExecutionResult> rejectOutput(HensuState state, String nodeId, String reason) {
+        logger.warning("Rejecting output from node [" + nodeId + "]: " + reason);
+        return Optional.of(
+                new ExecutionResult.Failure(
+                        state,
+                        new IllegalStateException("Node [" + nodeId + "] output " + reason)));
     }
 }

--- a/hensu-core/src/main/java/io/hensu/core/util/AgentOutputValidator.java
+++ b/hensu-core/src/main/java/io/hensu/core/util/AgentOutputValidator.java
@@ -1,0 +1,93 @@
+package io.hensu.core.util;
+
+import java.nio.charset.StandardCharsets;
+import java.util.regex.Pattern;
+
+/// Validates LLM-generated node output before it is stored in workflow state.
+///
+/// LLM outputs are non-deterministic and treated as untrusted data. This validator
+/// applies defense-in-depth checks tailored to the specific threats posed by agentic
+/// outputs, which differ from user-supplied REST input in both scope and character set.
+///
+/// ### Checks Provided
+/// - **ASCII control characters** — null bytes and non-printable chars that degrade
+///   downstream text processing ({@link #containsDangerousChars(String)})
+/// - **Unicode manipulation characters** — invisible and directional Unicode chars
+///   that can hide content, weaponize prompt injection, or corrupt downstream display
+///   ({@link #containsUnicodeTricks(String)})
+/// - **Payload size** — oversized outputs that could exhaust memory or storage
+///   ({@link #exceedsSizeLimit(String, int)} with {@link #MAX_LLM_OUTPUT_BYTES})
+///
+/// ### Relationship to Server-Side Validation
+/// This class is intentionally separate from `InputValidator` in `hensu-server`.
+/// REST input and LLM output are distinct trust boundaries with different threat models:
+/// REST input is short, user-typed, and identity-validated; LLM output is long,
+/// machine-generated, and carries Unicode-level injection risks that REST input does not.
+///
+/// @implNote Stateless utility class. All methods are pure functions — no side effects,
+/// no shared mutable state. Safe to call from any thread.
+///
+/// @see io.hensu.core.execution.pipeline.OutputExtractionPostProcessor
+public final class AgentOutputValidator {
+
+    /// ASCII control characters that are never legitimate in agent output.
+    /// Excludes TAB (0x09), LF (0x0A), CR (0x0D) which are valid in free text.
+    static final Pattern DANGEROUS_CONTROL =
+            Pattern.compile("[\\x00-\\x08\\x0B\\x0C\\x0E-\\x1F\\x7F]");
+
+    /// Unicode characters that can be used for visual deception or prompt injection.
+    ///
+    /// Covers:
+    /// - **RTL/LTR directional overrides**: U+202A–U+202E (LRE, RLE, PDF, LRO, RLO)
+    /// - **Unicode isolates**: U+2066–U+2069 (LRI, RLI, FSI, PDI)
+    /// - **Zero-width chars**: U+200B (ZWSP), U+200C (ZWNJ), U+200D (ZWJ)
+    /// - **Byte-order mark**: U+FEFF (BOM)
+    static final Pattern UNICODE_TRICKS =
+            Pattern.compile("[\u202A-\u202E\u2066-\u2069\u200B-\u200D\uFEFF]");
+
+    /// Maximum allowed LLM node output size in bytes (4 MB).
+    ///
+    /// Set higher than the REST input cap to accommodate legitimately large agentic
+    /// outputs such as long documents, generated code, or research summaries.
+    /// Outputs exceeding this limit indicate runaway generation and are rejected
+    /// to protect downstream pipeline stages from memory exhaustion.
+    public static final int MAX_LLM_OUTPUT_BYTES = 4_194_304;
+
+    private AgentOutputValidator() {}
+
+    /// Checks whether the value contains dangerous ASCII control characters.
+    ///
+    /// Detects null bytes and non-printable control characters
+    /// (U+0000–U+0008, U+000B, U+000C, U+000E–U+001F, U+007F).
+    /// TAB, LF, and CR are not considered dangerous.
+    ///
+    /// @param value the string to check, may be null
+    /// @return `true` if the value contains illegal control characters;
+    ///         `false` if null or clean
+    public static boolean containsDangerousChars(String value) {
+        return value != null && DANGEROUS_CONTROL.matcher(value).find();
+    }
+
+    /// Checks whether the value contains Unicode characters used for visual manipulation.
+    ///
+    /// Detects bidirectional override characters, Unicode isolates, zero-width characters,
+    /// and byte-order marks that can be used to hide malicious content, redirect text
+    /// rendering, or carry covert prompt injection payloads in agentic outputs.
+    ///
+    /// @param value the string to check, may be null
+    /// @return `true` if the value contains Unicode manipulation characters;
+    ///         `false` if null or clean
+    public static boolean containsUnicodeTricks(String value) {
+        return value != null && UNICODE_TRICKS.matcher(value).find();
+    }
+
+    /// Checks whether the value exceeds the given byte-size limit (UTF-8 encoded).
+    ///
+    /// @param value    the string to measure, may be null
+    /// @param maxBytes the maximum allowed size in bytes, must be positive
+    /// @return `true` if the UTF-8 byte length of `value` exceeds `maxBytes`;
+    ///         `false` if null or within limit
+    public static boolean exceedsSizeLimit(String value, int maxBytes) {
+        return value != null && value.getBytes(StandardCharsets.UTF_8).length > maxBytes;
+    }
+}

--- a/hensu-core/src/test/java/io/hensu/core/util/AgentOutputValidatorTest.java
+++ b/hensu-core/src/test/java/io/hensu/core/util/AgentOutputValidatorTest.java
@@ -1,0 +1,227 @@
+package io.hensu.core.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("AgentOutputValidator")
+class AgentOutputValidatorTest {
+
+    // ——————————————————————————————————————————————————————
+    // containsDangerousChars
+    // ——————————————————————————————————————————————————————
+
+    @Test
+    @DisplayName("TAB (0x09) is allowed — range \\x00-\\x08 must not accidentally include it")
+    void shouldAllowTab() {
+        assertThat(AgentOutputValidator.containsDangerousChars("column1\tcolumn2")).isFalse();
+    }
+
+    @Test
+    @DisplayName("LF (0x0A) is allowed — multiline LLM output is normal")
+    void shouldAllowLineFeed() {
+        assertThat(AgentOutputValidator.containsDangerousChars("line1\nline2\nline3")).isFalse();
+    }
+
+    @Test
+    @DisplayName("CR (0x0D) is allowed — Windows CRLF line endings permitted")
+    void shouldAllowCarriageReturn() {
+        assertThat(AgentOutputValidator.containsDangerousChars("line1\r\nline2")).isFalse();
+    }
+
+    @Test
+    @DisplayName("BS (0x08) is rejected — end boundary of first range \\x00-\\x08")
+    void shouldRejectBackspace() {
+        assertThat(AgentOutputValidator.containsDangerousChars("back\u0008space")).isTrue();
+    }
+
+    @Test
+    @DisplayName("VT (0x0B) is rejected — explicitly included between LF and FF")
+    void shouldRejectVerticalTab() {
+        assertThat(AgentOutputValidator.containsDangerousChars("line\u000Bbreak")).isTrue();
+    }
+
+    @Test
+    @DisplayName("FF (0x0C) is rejected — explicitly included between VT and CR")
+    void shouldRejectFormFeed() {
+        assertThat(AgentOutputValidator.containsDangerousChars("page\u000Cbreak")).isTrue();
+    }
+
+    @Test
+    @DisplayName("SO (0x0E) is rejected — start boundary of range \\x0E-\\x1F")
+    void shouldRejectShiftOut() {
+        assertThat(AgentOutputValidator.containsDangerousChars("bad\u000Echar")).isTrue();
+    }
+
+    @Test
+    @DisplayName("US (0x1F) is rejected — end boundary of range \\x0E-\\x1F")
+    void shouldRejectUnitSeparator() {
+        assertThat(AgentOutputValidator.containsDangerousChars("bad\u001Fchar")).isTrue();
+    }
+
+    @Test
+    @DisplayName("SPACE (0x20) is allowed — first printable ASCII char, pattern must not bleed up")
+    void shouldAllowSpace() {
+        assertThat(AgentOutputValidator.containsDangerousChars("hello world")).isFalse();
+    }
+
+    @Test
+    @DisplayName("DEL (0x7F) is rejected — singleton at upper ASCII boundary")
+    void shouldRejectDel() {
+        assertThat(AgentOutputValidator.containsDangerousChars("del\u007Fchar")).isTrue();
+    }
+
+    @Test
+    @DisplayName("0x80 is allowed — pattern must not bleed into extended ASCII / Latin-1")
+    void shouldAllowFirstExtendedAscii() {
+        assertThat(AgentOutputValidator.containsDangerousChars("\u0080extended")).isFalse();
+    }
+
+    @Test
+    @DisplayName(
+            "NUL byte (0x00) is rejected — classic injection and null-termination attack vector")
+    void shouldRejectNulByte() {
+        assertThat(AgentOutputValidator.containsDangerousChars("before\u0000after")).isTrue();
+    }
+
+    @Test
+    @DisplayName("control char buried deep in long string is detected regardless of position")
+    void shouldDetectControlCharEmbeddedInLongString() {
+        String payload = "x".repeat(1000) + "\u0007" + "y".repeat(1000);
+        assertThat(AgentOutputValidator.containsDangerousChars(payload)).isTrue();
+    }
+
+    @Test
+    @DisplayName("null input returns false without throwing")
+    void shouldReturnFalseForNullDangerous() {
+        assertThat(AgentOutputValidator.containsDangerousChars(null)).isFalse();
+    }
+
+    // ——————————————————————————————————————————————————————
+    // containsUnicodeTricks
+    // ——————————————————————————————————————————————————————
+
+    @Test
+    @DisplayName("LRE (U+202A) is rejected — start of directional override range")
+    void shouldRejectLre() {
+        assertThat(AgentOutputValidator.containsUnicodeTricks("text\u202Amore")).isTrue();
+    }
+
+    @Test
+    @DisplayName(
+            "RLO (U+202E) is rejected — end of directional override range, classic hiding attack")
+    void shouldRejectRlo() {
+        assertThat(AgentOutputValidator.containsUnicodeTricks("benign\u202Evil")).isTrue();
+    }
+
+    @Test
+    @DisplayName(
+            "U+202F (NARROW NO-BREAK SPACE) is allowed — char immediately after U+202E, range must not overshoot")
+    void shouldAllowNarrowNoBreakSpace() {
+        assertThat(AgentOutputValidator.containsUnicodeTricks("ok\u202Fspacing")).isFalse();
+    }
+
+    @Test
+    @DisplayName("LRI (U+2066) is rejected — start of Unicode isolate range")
+    void shouldRejectLri() {
+        assertThat(AgentOutputValidator.containsUnicodeTricks("text\u2066isolated")).isTrue();
+    }
+
+    @Test
+    @DisplayName("PDI (U+2069) is rejected — end of Unicode isolate range")
+    void shouldRejectPdi() {
+        assertThat(AgentOutputValidator.containsUnicodeTricks("text\u2069end")).isTrue();
+    }
+
+    @Test
+    @DisplayName("U+206A is allowed — char immediately after U+2069, range must not overshoot")
+    void shouldAllowCharJustAfterIsolateRange() {
+        assertThat(AgentOutputValidator.containsUnicodeTricks("ok\u206Atext")).isFalse();
+    }
+
+    @Test
+    @DisplayName("ZWSP (U+200B) is rejected — start of zero-width range, invisible spacing attack")
+    void shouldRejectZwsp() {
+        assertThat(AgentOutputValidator.containsUnicodeTricks("zero\u200Bwidth")).isTrue();
+    }
+
+    @Test
+    @DisplayName("ZWJ (U+200D) is rejected — end of zero-width range")
+    void shouldRejectZwj() {
+        assertThat(AgentOutputValidator.containsUnicodeTricks("zero\u200Djoiner")).isTrue();
+    }
+
+    @Test
+    @DisplayName("BOM (U+FEFF) is rejected — byte-order mark has no place in LLM text content")
+    void shouldRejectBom() {
+        assertThat(AgentOutputValidator.containsUnicodeTricks("\uFEFFprefixed content")).isTrue();
+    }
+
+    @Test
+    @DisplayName("legitimate Arabic text is allowed — RTL script must not produce false positives")
+    void shouldAllowLegitimateArabicText() {
+        // "العربية" — natural RTL script, no directional override characters
+        assertThat(
+                        AgentOutputValidator.containsUnicodeTricks(
+                                "\u0627\u0644\u0639\u0631\u0628\u064A\u0629"))
+                .isFalse();
+    }
+
+    @Test
+    @DisplayName("legitimate Hebrew text is allowed — another natural RTL script")
+    void shouldAllowLegitimateHebrewText() {
+        // "שלום" — natural RTL script
+        assertThat(AgentOutputValidator.containsUnicodeTricks("\u05E9\u05DC\u05D5\u05DD"))
+                .isFalse();
+    }
+
+    @Test
+    @DisplayName("null input returns false without throwing")
+    void shouldReturnFalseForNullUnicode() {
+        assertThat(AgentOutputValidator.containsUnicodeTricks(null)).isFalse();
+    }
+
+    // ——————————————————————————————————————————————————————
+    // exceedsSizeLimit
+    // ——————————————————————————————————————————————————————
+
+    @Test
+    @DisplayName(
+            "emoji (4 UTF-8 bytes) counted by byte length, not char length — catches length() vs getBytes() bug")
+    void shouldCountBytesNotCharLengthForEmoji() {
+        // U+1F600 GRINNING FACE: 4 bytes in UTF-8, but String.length() = 2 (surrogate pair)
+        String emoji = "\uD83D\uDE00"; // 😀
+        assertThat(emoji).hasSize(2); // confirms the trap: char length is 2
+        assertThat(AgentOutputValidator.exceedsSizeLimit(emoji, 3)).isTrue();
+        assertThat(AgentOutputValidator.exceedsSizeLimit(emoji, 4)).isFalse();
+    }
+
+    @Test
+    @DisplayName("3-byte UTF-8 char (€) counted correctly at boundary")
+    void shouldCountThreeByteCharsCorrectly() {
+        String euro = "\u20AC"; // € — 3 bytes in UTF-8
+        assertThat(AgentOutputValidator.exceedsSizeLimit(euro, 2)).isTrue();
+        assertThat(AgentOutputValidator.exceedsSizeLimit(euro, 3)).isFalse();
+    }
+
+    @Test
+    @DisplayName("payload at exact byte limit is not rejected")
+    void shouldAllowPayloadAtExactLimit() {
+        String s = "abc"; // 3 ASCII bytes
+        assertThat(AgentOutputValidator.exceedsSizeLimit(s, 3)).isFalse();
+    }
+
+    @Test
+    @DisplayName("payload one byte over limit is rejected")
+    void shouldRejectPayloadOneByteOverLimit() {
+        String s = "abcd"; // 4 ASCII bytes
+        assertThat(AgentOutputValidator.exceedsSizeLimit(s, 3)).isTrue();
+    }
+
+    @Test
+    @DisplayName("null input returns false without throwing")
+    void shouldReturnFalseForNullSize() {
+        assertThat(AgentOutputValidator.exceedsSizeLimit(null, 100)).isFalse();
+    }
+}


### PR DESCRIPTION
…on pipeline

- Introduce domain-specific validation gates for LLM outputs in the core engine
- Implement strict control character filtering (x00-x1F) while preserving TAB/LF
- Add Unicode Bidirectional (Bidi) and Isolate character detection for security
- Fix byte-size limit logic to use UTF-8 getBytes().length over String.length()
- Integrate AgentOutputValidator into OutputExtractionPostProcessor
- Update READMEs and developer guides with the new Agentic Output Validation spec

Resolve: #25