### PR TITLE
refactor: decouple execution lifecycle into pre/post processor pipelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,10 +102,10 @@ hensu-langchain4j-adapter     # LangChain4j integration (Claude, GPT, Gemini, De
 - `ProcessorPipeline` - Orchestrates pre/post node execution processor chains
 
 **Execution Lifecycle**: The `WorkflowExecutor` processes each node through a strict PRE-EXECUTE-POST pipeline.
-Post-execution logic is handled by a chain of `PostNodeExecutionProcessor`s in fixed order: output extraction → history
-recording → human review → rubric evaluation → transition resolution. Any processor can short-circuit the pipeline by
-returning a terminal `ExecutionResult`. This design isolates cross-cutting concerns (e.g., adding a new rubric) from
-the core agent execution logic.
+Pre-execution processors run in order: checkpoint → node start. Post-execution processors run in order: output
+extraction → node complete → history recording → human review → rubric evaluation → transition resolution. Any
+processor can short-circuit the pipeline by returning a terminal `ExecutionResult`. This design isolates cross-cutting
+concerns (e.g., adding a new rubric) from the core agent execution logic.
 
 **Server-Specific Components** (in `hensu-server`):
 
@@ -166,7 +166,7 @@ Execution state flows through three types:
 
 **Checkpoint lifecycle** (inter-node persistence for failover):
 
-1. `WorkflowExecutor.executeLoop()` calls `listener.onCheckpoint(state)` before each non-end node
+1. `CheckpointPreProcessor` fires `listener.onCheckpoint(state)` as the first step before each non-end node
 2. `WorkflowService` implements `ExecutionListener.onCheckpoint()` to save a `HensuSnapshot` with reason `"checkpoint"`
 3. If server dies mid-execution → restart → `findPaused()` returns interrupted executions → resume from last checkpoint
 

--- a/hensu-core/README.md
+++ b/hensu-core/README.md
@@ -229,11 +229,14 @@ hensu-core/src/main/java/io/hensu/core/
 │   │   └── EndNodeExecutor.java       # Terminal nodes
 │   ├── pipeline/
 │   │   ├── NodeExecutionProcessor.java          # Base processor interface
-│   │   ├── PreNodeExecutionProcessor.java       # Pre-execution processor interface
-│   │   ├── PostNodeExecutionProcessor.java      # Post-execution processor interface
+│   │   ├── PreNodeExecutionProcessor.java       # Pre-execution processor marker interface
+│   │   ├── PostNodeExecutionProcessor.java      # Post-execution processor marker interface
 │   │   ├── ProcessorContext.java                # Per-iteration context (node + result + state)
 │   │   ├── ProcessorPipeline.java               # Orchestrates pre/post processor chains
+│   │   ├── CheckpointPreProcessor.java          # Fires listener.onCheckpoint for crash-recovery persistence
+│   │   ├── NodeStartPreProcessor.java           # Fires listener.onNodeStart for observability
 │   │   ├── OutputExtractionPostProcessor.java   # Validates then stores node output in state context
+│   │   ├── NodeCompletePostProcessor.java       # Fires listener.onNodeComplete for observability
 │   │   ├── HistoryPostProcessor.java            # Records execution steps for audit
 │   │   ├── ReviewPostProcessor.java             # Human-in-the-loop review checkpoints
 │   │   ├── RubricPostProcessor.java             # Quality evaluation + auto-backtrack

--- a/hensu-core/src/main/java/io/hensu/core/execution/pipeline/CheckpointPreProcessor.java
+++ b/hensu-core/src/main/java/io/hensu/core/execution/pipeline/CheckpointPreProcessor.java
@@ -1,0 +1,30 @@
+package io.hensu.core.execution.pipeline;
+
+import io.hensu.core.execution.result.ExecutionResult;
+import java.util.Optional;
+
+/// Fires the {@link io.hensu.core.execution.ExecutionListener#onCheckpoint} callback
+/// before each node executes.
+///
+/// This is the first processor in the pre-execution pipeline. It signals to
+/// external observers (e.g., {@code WorkflowService}) that the workflow state is
+/// fully consistent and safe to persist for crash-recovery purposes.
+///
+/// ### Contracts
+/// - **Precondition**: `context.result()` is {@code null} (pre-execution pipeline)
+/// - **Postcondition**: Always returns empty (never short-circuits)
+/// - **Side effects**: Delegates to the registered
+/// {@link io.hensu.core.execution.ExecutionListener}
+///
+/// @implNote Stateless. Safe to reuse across loop iterations.
+///
+/// @see io.hensu.core.execution.ExecutionListener#onCheckpoint
+/// @see NodeStartPreProcessor for the subsequent pre-execution processor
+public final class CheckpointPreProcessor implements PreNodeExecutionProcessor {
+
+    @Override
+    public Optional<ExecutionResult> process(ProcessorContext context) {
+        context.executionContext().getListener().onCheckpoint(context.state());
+        return Optional.empty();
+    }
+}

--- a/hensu-core/src/main/java/io/hensu/core/execution/pipeline/NodeCompletePostProcessor.java
+++ b/hensu-core/src/main/java/io/hensu/core/execution/pipeline/NodeCompletePostProcessor.java
@@ -1,0 +1,39 @@
+package io.hensu.core.execution.pipeline;
+
+import io.hensu.core.execution.result.ExecutionResult;
+import java.util.Optional;
+
+/// Fires the {@link io.hensu.core.execution.ExecutionListener#onNodeComplete} callback
+/// after a node's output has been extracted and validated.
+///
+/// This processor runs second in the post-execution pipeline, after
+/// {@link OutputExtractionPostProcessor} has stored the node output in the
+/// state context, ensuring observers receive a consistent view of the result.
+///
+/// ### Contracts
+/// - **Precondition**: `context.result()` is non-null (post-execution pipeline)
+/// - **Postcondition**: Always returns empty (never short-circuits)
+/// - **Side effects**: Delegates to the registered
+/// {@link io.hensu.core.execution.ExecutionListener}
+///
+/// ### Pipeline Position
+/// ```
+/// OutputExtractionPostProcessor    ← output validated and stored in state
+/// NodeCompletePostProcessor        ← this processor fires onNodeComplete
+/// HistoryPostProcessor             ← step recorded with final output
+/// ```
+///
+/// @implNote Stateless. Safe to reuse across loop iterations.
+///
+/// @see io.hensu.core.execution.ExecutionListener#onNodeComplete
+/// @see OutputExtractionPostProcessor for the preceding post-execution processor
+public final class NodeCompletePostProcessor implements PostNodeExecutionProcessor {
+
+    @Override
+    public Optional<ExecutionResult> process(ProcessorContext context) {
+        context.executionContext()
+                .getListener()
+                .onNodeComplete(context.currentNode(), context.result());
+        return Optional.empty();
+    }
+}

--- a/hensu-core/src/main/java/io/hensu/core/execution/pipeline/NodeStartPreProcessor.java
+++ b/hensu-core/src/main/java/io/hensu/core/execution/pipeline/NodeStartPreProcessor.java
@@ -1,0 +1,30 @@
+package io.hensu.core.execution.pipeline;
+
+import io.hensu.core.execution.result.ExecutionResult;
+import java.util.Optional;
+
+/// Fires the {@link io.hensu.core.execution.ExecutionListener#onNodeStart} callback
+/// before each node executes.
+///
+/// This is the second processor in the pre-execution pipeline, running immediately
+/// after {@link CheckpointPreProcessor}. It signals to observers that a node is
+/// about to begin execution.
+///
+/// ### Contracts
+/// - **Precondition**: `context.result()` is {@code null} (pre-execution pipeline)
+/// - **Postcondition**: Always returns empty (never short-circuits)
+/// - **Side effects**: Delegates to the registered
+/// {@link io.hensu.core.execution.ExecutionListener}
+///
+/// @implNote Stateless. Safe to reuse across loop iterations.
+///
+/// @see io.hensu.core.execution.ExecutionListener#onNodeStart
+/// @see CheckpointPreProcessor for the preceding pre-execution processor
+public final class NodeStartPreProcessor implements PreNodeExecutionProcessor {
+
+    @Override
+    public Optional<ExecutionResult> process(ProcessorContext context) {
+        context.executionContext().getListener().onNodeStart(context.currentNode());
+        return Optional.empty();
+    }
+}


### PR DESCRIPTION
- Relocate hardcoded ExecutionListener calls to specialized processors
- Simplify WorkflowExecutor.executeLoop to a pure pipeline orchestrator

Resolve: #22