### PR TITLE
chore(agents): restructure rules, add skills/commands, register Gemin…

### DIFF
--- a/.claude/commands/assess-claude.md
+++ b/.claude/commands/assess-claude.md
@@ -1,0 +1,34 @@
+---
+description: Get Gemini's cynical review on Claude's work.
+---
+# Assess Claude
+
+Subject: $ARGUMENTS (or last substantive reply/diff).
+
+Token rule: see `01-model-coordination.md` §2. Never read files into your own context; Gemini eats tokens, not you.
+
+1. **Resolve subject:**
+   - Files/dirs → `@path` (glob-friendly).
+   - Commit/branch → `git show <ref> > .claude/tmp/subject.patch` then `@.claude/tmp/subject.patch`.
+   - Uncommitted → `git diff > .claude/tmp/subject.patch` then `@.claude/tmp/subject.patch`.
+   - Add ≤2 lines rationale.
+
+2. **Query Gemini** (`mcp__gemini__ask-gemini`, `gemini-3.1-pro-preview`):
+> Cynical Researcher. Read referenced paths. Audit against:
+> (1) Correctness — edge cases, concurrency, error paths.
+> (2) Hensu invariants — GraalVM native (no reflection/classpath scanning/ThreadLocal), virtual-thread safety (no pinning `synchronized`), multi-tenant ScopedValue isolation.
+> (3) SOLID/KISS/YAGNI/DRY — duplication between `hensu-core`/`hensu-server`.
+> (4) Conflicts with existing code.
+> (5) Tests — real bugs caught, not coverage theater.
+>
+> OUTPUT — strict, one line per finding, no prose, no preamble, no summary:
+> `BLOCKER  | path:line | terse reason`
+> `CONCERN  | path:line | terse reason`
+> `NIT      | path:line | terse reason`
+> Last line: `VERDICT: ship | ship-after-blockers | rework`
+> Silence on anything acceptable. No "KEEP" / "LGTM" lines.
+
+3. **Output:** paste Gemini's raw (terse) response verbatim.
+
+4. **Stance** (one token each, wait for user):
+   - `accept` / `reject(reason)` / `evidence` (→ `/assess-gemini`)

--- a/.claude/commands/assess-gemini.md
+++ b/.claude/commands/assess-gemini.md
@@ -1,0 +1,21 @@
+---
+description: Verify Gemini's last opinion by requesting evidence.
+---
+# Assess Gemini
+
+Target: $ARGUMENTS (or Gemini's last reply).
+
+Token rule: see `01-model-coordination.md` §2. Do NOT `Read` files just to confirm citations — defer verification to the moment you edit that code. Only `Read` if the claim would change the user's decision *before* any edit.
+
+1. **List disputed claims** lacking `path:line`. Skip if all claims already cited concretely.
+
+2. **Query Gemini** (`mcp__gemini__ask-gemini`, `gemini-3.1-flash-lite-preview`) — only if step 1 non-empty:
+> Back prior claims with exact `path:line-range` + quoted block. No re-argument, no new claims, no fabrication.
+
+3. **Assess** (one line per disputed claim):
+   - `agree    | path:line | quoted evidence`
+   - `disagree | path:line | counter-quote`
+   - `unclear  | path:line | what's missing`
+   - `missed   | path:line | what Gemini ignored`
+
+4. **Recommend** ≤2 sentences. Wait for user.

--- a/.claude/commands/test-audit.md
+++ b/.claude/commands/test-audit.md
@@ -1,0 +1,31 @@
+---
+description: Audit tests via Gemini (DROP/WEAK/ADD).
+---
+# Test Audit
+
+Target: $ARGUMENTS (or ask user which tests/paths/diff).
+
+Token rule: see `01-model-coordination.md` §2. Never inline test code or diffs.
+
+1. **Resolve target:**
+   - Files/dirs → `@path` (glob-friendly).
+   - Uncommitted tests → `git diff -- '*Test*' '*test*' > .claude/tmp/tests.patch` then `@.claude/tmp/tests.patch`.
+
+2. **Query Gemini** (`mcp__gemini__ask-gemini`, `gemini-3.1-pro-preview`):
+> Cynical Researcher. Read referenced test paths. Question: "Can this catch a real prod bug?"
+> Repo has ~1000 tests; net delta must be ≤ 0. Prefer DROP.
+> Classify:
+> - DROP — tautological, trivial, framework/language, duplicate, or asserts only what the type system guarantees.
+> - WEAK — real target, poor execution (over-mocked, asserts impl detail, brittle).
+> - ADD — uncovered prod failure mode. Be stingy.
+>
+> OUTPUT — strict, one line per finding, no prose, no preamble:
+> `DROP | path:line | test name | bug it misses`
+> `WEAK | path:line | test name | concrete rewrite`
+> `ADD  | path:— | area          | prod failure mode`
+> Last line: `NET: -X +Y = {sign}Z`
+> SILENCE ON KEEP. Do not emit anything for acceptable tests.
+
+3. **Output:** paste Gemini's raw (terse) response verbatim.
+
+4. **Recommend** top 3 to action. Wait for user.

--- a/.claude/rules/00-master.md
+++ b/.claude/rules/00-master.md
@@ -11,6 +11,11 @@ You are the Lead Software Engineer for Hensu, an orchestration engine for AI wor
 MANDATORY: Before every session:
 - You MUST read and adhere to the standards in AGENTS.md.
 - Adhere to the "Model Coordination" in `01-model-coordination.md`.
-- Adhere to the "GraalVM Native Image" in `10-java-standards.md`.
-- Adhere to the "Hensu Java & Kotlin Standards" in `20-native-safety.md`.
-- Document all public APIs following the [Javadoc Guide](../../docs/javadoc-guide.md).
+- Adhere to the "Chat Density Protocol" in `02-output-density.md` (dense chat, prose for all written artifacts).
+- Adhere to the "Hensu Java & Kotlin Standards" in `10-java-standards.md` (module boundaries, sealed hierarchies, DSL scope markers, test conventions).
+- Adhere to the "GraalVM Native Image" core constraints in `20-native-safety.md` (no reflection, no ThreadLocal, no classpath scanning).
+
+Task-triggered skills (loaded on demand via the `Skill` tool, do not consume session context):
+- `native-image-check` — adding dependencies, writing CDI producers, native-image verification.
+- `visual-style` — diagrams, Mermaid blocks, ASCII architecture art, badges.
+- `javadoc` — authoring or editing Javadoc/KDoc on public APIs.

--- a/.claude/rules/01-model-coordination.md
+++ b/.claude/rules/01-model-coordination.md
@@ -1,75 +1,39 @@
 # 01-model-coordination.md
 
-# Model Coordination & Persistence Rules
+## Mode Auto-Detection
 
-## 0. Mode Detection (Auto-Fallback)
+Ping `mcp__gemini__ping` at session start.
 
-**This section runs first, every session. No developer action required.**
+- **Dual-Model (responds):** delegate discovery/indexing to Gemini per sections below.
+- **Single-Model (absent or fails):** skip all `mcp__gemini__*` calls silently. Use `Glob`/`Grep` for discovery; Claude self-reviews dependencies inline.
 
-At session start, probe for Gemini MCP availability by attempting `mcp__gemini__ping`.
+## Persona & Collaboration (Dual-Model)
 
-| Result                       | Active Mode           |
-|------------------------------|-----------------------|
-| Tool exists and responds     | **Dual-Model Mode**   |
-| Tool absent or call rejected | **Single-Model Mode** |
+- **Claude — Lead Architect & Implementer.** Owns core logic, architectural integrity, final edits. Token-poor: never ingest raw files when Gemini can pre-digest them.
+- **Gemini — Cynical Researcher / Indexer.** 1M-window scan, noise reduction, blunt dependency reviews. Must discard anything less than 100% relevant to the task.
 
-### Dual-Model Mode (Gemini MCP available)
+## Model Routing
 
-Follow sections 1–5 below as written. Claude is Lead Implementer; Gemini is Cynical Researcher/Indexer.
+- **Discovery / Indexing:** `gemini-3.1-flash-lite-preview`
+- **Logic / Refactoring:** `gemini-3.1-pro-preview`
 
-### Single-Model Mode (Gemini MCP not available)
+## Discovery Rule (Dual-Model)
 
-Claude acts as both Lead Implementer **and** Researcher. Adjust the protocol:
+- **Prohibited:** `Glob`, `Grep`, `Bash`-based file discovery, recursive `ls`.
+- Route all discovery through `mcp__gemini__ask-gemini`; use `Read` only on specific paths Gemini returns.
 
-- **Skip** all `mcp__gemini__*` calls — do not error, do not prompt the developer.
-- **Lift the grep/ls prohibition** from §2: use `Glob` and `Grep` (dedicated tools) for discovery.
-- **§1 Gemini persona** is dormant — Claude self-reviews dependencies for virtual-thread and native-image safety.
-- **§5 Cynical Review** is performed inline by Claude before accepting a new dependency.
-- All other rules (AGENTS.md warm-start, Memory MCP, pathing) remain active.
+## Persistence & State
 
-> **Developer note:** To enable Dual-Model Mode, plug the `gemini-mcp` server into your IDE or CLI config.
-> Nothing else changes — the rules self-adapt.
+- Warm-start every session with `AGENTS.md`.
+- Append architectural decisions to `AGENTS.md` immediately — do not keep them in chat history.
+- Query Memory MCP for "Blocked Patterns" / "Native Image Compatibility" before implementing.
 
----
+## Dependency Vetting Checklist
 
-## 1. Persona & Collaboration
+When adding any new dependency, verify:
+1. **Virtual-thread safe:** no `synchronized` blocks that pin carrier threads.
+2. **Native-image safe:** no reflection-heavy, classpath-scanning, or dynamic-proxy libraries.
 
-- **Claude (Lead Architect & Implementer):** - **Focus:** Core logic, architectural integrity, and final code execution.
-    - **Constraint:** Maintain "Token-Poverty" mindset. Never ingest raw files if Gemini can provide a distilled
-      summary.
-- **Gemini (Cynical Researcher/Indexer):**
-    - **Focus:** High-context scanning (1M window), noise reduction, and "Bro-opinion" technical reviews.
-    - **Constraint:** Use `gemini-3.1-flash-lite-preview` for indexing. Your goal is to kill noise. If a code block isn't 100%
-      relevant to the specific task, discard it.
+## Pathing
 
-## 2. Token-Efficient Research Protocol (The "Pre-Filter" Hack)
-
-- **The Protocol:** For any task, Claude must first trigger Gemini with the following instruction:
-  > "Act as the Cynical Researcher. Scan the 1M context for [Task]. Strip boilerplate, identify logic 'hot spots,' and
-  provide a minimalist index of only the essential snippets with a blunt one-sentence opinion on each."
-- **Model Routing:**
-    - **Discovery/Indexing:** `gemini-3.1-flash-lite-preview`.
-    - **Complex Logic/Refactoring:** `gemini-3.1-pro-preview` (or latest Pro model).
-- **Prohibited:** No `grep` or recursive `ls`. These are legacy "blind" tools. Use Gemini's semantic understanding to
-  find what matters.
-
-## 3. Shared Persistence (AGENTS.md)
-
-- **Source of Truth:** `AGENTS.md` is the "Hensu Brain."
-- **Warm Start:** Every session begins with a `read_file` of `AGENTS.md`.
-- **Atomic Commits:** When an architectural decision is finalized (e.g., SSE multi-tenancy rules), use `save_memory` or
-  append to `AGENTS.md` immediately. Do not keep decisions only in chat history.
-
-## 4. Knowledge Graph (Memory MCP)
-
-- **Relation Mapping:** Use the `memory` MCP server to map dependencies (e.g., "Hensu-Server *consumes* Hensu-DSL").
-- **Constraint Check:** Before implementing, query Memory for "Blocked Patterns" or "Native Image Compatibility" notes
-  recorded in previous sessions.
-
-## 5. Technical Guardrails (The "Hensu" Stack)
-
-- **Stack:** Java 25 (Project Loom) / Kotlin 2.x / Quarkus.
-- **Cynical Review:** Gemini must verify all new dependencies for:
-    1. **Virtual Thread Friendly:** No synchronized blocks pinning threads.
-    2. **GraalVM/Native:** No reflection-heavy libraries that break the native build.
-- **Pathing:** Use `$(pwd)/path` for all tool calls to prevent context drift.
+Always use `$(pwd)/path` in tool calls to prevent context drift.

--- a/.claude/rules/02-output-density.md
+++ b/.claude/rules/02-output-density.md
@@ -1,0 +1,48 @@
+# 02-output-density.md — Chat Density Protocol
+
+Applies ONLY to assistant chat replies in this session. Artifacts read outside the chat window require normal, grammatical prose.
+
+## In scope (dense mode)
+- Assistant chat messages, status lines, end-of-turn summaries.
+- Clarifying questions to the user.
+- Inline tool-use narration.
+
+## Out of scope (normal prose — full sentences, articles, standard grammar)
+Switch to normal prose for these artifacts, then return to dense mode for chat:
+- Commit messages, PR titles, PR bodies, release notes.
+- Javadoc, KDoc, code comments (see `javadoc` skill).
+- Markdown docs under `docs/`, `README.md`, `AGENTS.md`, rule files.
+- Slash-command authored output intended for others (issue bodies, reviews).
+- Error messages, log strings, user-facing product copy.
+- Code identifiers, string literals, test descriptions.
+
+## Dense-mode rules (chat only)
+- No pleasantries ("Sure!", "Great question", "Happy to help").
+- No hedging without evidence.
+- No recapping user inputs or past actions.
+- No trailing summaries unless requested (end-of-turn = ≤1 sentence).
+- Use imperative mood for actions.
+- Use bulleted lists for ≥3 parallel items.
+- Drop articles (a/an/the) in bullets, status lines, and headings if clarity is preserved. Keep them in full sentences.
+- No filler transitions ("Now,", "So,", "Basically,").
+- Limit tool-use meta-narration to ≤1 intent sentence.
+- Use arrow notation (`X → Y`) for causal chains.
+- For ambiguous intent: ask one short question, no preamble.
+
+### Example
+
+Verbose (reject):
+> Great question! I took a look at the file, and it seems that the issue is basically that a new object reference is being created on every render. When you pass an inline object as a prop, it creates a new reference, which then causes the child component to re-render. So, you'll want to wrap it in `useMemo` to fix this.
+
+Dense (accept):
+> Inline obj prop → new ref each render → child re-renders. Wrap in `useMemo`.
+
+## Drop dense mode for
+Revert to full prose when terseness risks harm or ambiguity:
+- Security warnings and threat-model explanations.
+- Confirmation prompts before irreversible or destructive actions (force push, `rm -rf`, dropping tables, deleting branches).
+- Multi-step sequences where fragment ordering or dropped articles could change the meaning or lead to misexecution.
+- When the user explicitly asks for clarification of something already stated tersely.
+
+## Override
+Honor per-turn verbose requests ("explain in detail", "walk me through"); revert next turn.

--- a/.claude/rules/10-java-standards.md
+++ b/.claude/rules/10-java-standards.md
@@ -1,85 +1,30 @@
-# 10-java-standards.md
+# 10-java-standards.md — Hensu Java/Kotlin Invariants
 
-# Hensu Java & Kotlin Standards
+Generic SOLID/KISS/YAGNI/DRY apply silently. Only project-specific rules below.
 
-This document defines the strict coding standards for the Hensu engine. Adherence ensures
-**GraalVM native-image safety** and **multi-tenant isolation**.
+## Module boundaries
 
----
+- `hensu-core` has **zero third-party deps** beyond JDK 25. No vendor SDKs, no vendor `if/else`.
+- All `Agent` impls are interchangeable (Liskov). Capability differences go through narrow interfaces like `ToolCapable`, `Streamable` — never a God interface, never vendor-sniffing in the orchestration loop.
+- Shared constants/schema live in `hensu-core` so CLI and Server speak the same language.
+- Logic duplicated between `hensu-core` and `hensu-server` → extract to a shared util/base provider.
 
-## Engineering Philosophy (SOLID, KISS, YAGNI, DRY)
+## Concurrency
 
-You must justify every architectural change against these principles:
+- See `20-native-safety.md` §3 for the `ThreadLocal` ban and `ScopedValue` pattern.
+- Verify no data bleeds between parallel workflow nodes during fan-out/fan-in.
 
-### SOLID Protocol
+## Domain model
 
-* **S (Single Responsibility):** One class, one reason to change. Split executors from coordinators.
-* **O (Open/Closed):** Extend via interfaces. Do not modify the core orchestration loop for new providers.
-* **L (Liskov Substitution):** All `Agent` implementations must be interchangeable. No vendor-specific "if/else" logic
-  in the Core.
-* **I (Interface Segregation):** Favor many specific interfaces (e.g., `ToolCapable`, `Streamable`) over one "God"
-  interface.
-* **D (Dependency Inversion):** High-level logic must depend on abstractions. No direct dependencies on vendor SDKs in
-  `hensu-core`.
+- Domain results → `sealed interface` (e.g. `ExecutionResult`, `TransitionStatus`), consumed via `switch` pattern matching.
+- All domain models immutable; construct via `hensu-serialization` builder mixins.
 
-### KISS & YAGNI
+## Kotlin DSL
 
-* **Zero-Dependency Core:** No new libraries in `hensu-core` unless standard JVM (Java 25) is insufficient.
-* **Feature Restraint:** Do not build "future-proof" abstractions. Implement only what is required for the current
-  logic.
+- `@WorkflowDsl` (meta `@DslMarker`) on `WorkflowBuilder`, `GraphBuilder`, `NodeBuilder` — prevents scope leakage (an `agent { }` block must not see parent `node { }`).
 
-### DRY (Don't Repeat Yourself) & Single Source of Truth
+## Tests
 
-* **Logic Duplication:** If the same orchestration logic appears in both `hensu-core` and `hensu-server`, it must be
-  extracted into a shared internal utility or a base provider.
-* **Core Constants:** Do not hardcode strings for repeated constants. Use a shared `Constants` or `Schema` object
-  in the `core` module to ensure the CLI and Server speak the same language.
-* **The "Rule of Three":** Do not abstract code the first time it is repeated. Wait for the third occurrence to ensure
-  the abstraction is actually reusable and not a "leaky" coupling.
-* **SSOT (Single Source of Truth):** The `AGENTS.md` and the module rules are the SSOT for project intent.
-
----
-
-## Security: ScopedValues Over ThreadLocal
-
-To support high-concurrency Virtual Threads (Project Loom) and safe SaaS deployment, **`ScopedValues`** are mandatory
-for context propagation.
-
-* **RULE:** Never use `ThreadLocal`. It leads to memory leaks and context pollution in Virtual Thread pools.
-* **PATTERN:** Use `ScopedValue.where(CONTEXT, value).run(() -> { ... })` for passing tenant IDs, security tokens, and
-  workflow state.
-* **ISOLATION:** Rigorously verify that no data "bleeds" between workflow nodes during parallel execution.
-
----
-
-## Language Standards
-
-Hensu leverages the latest JVM features to reduce boilerplate and increase type safety.
-
-### **Java 25+ (Core & Server)**
-
-* **Sealed Hierarchies:** Use `sealed interface` for all domain results (e.g., `ExecutionResult`, `TransitionStatus`).
-* **Pattern Matching:** Use `switch` expression pattern matching for processing node types and workflow events.
-* **Immutability:** All domain models must be immutable. Use the builder pattern provided by the `hensu-serialization`
-  mixins.
-* **Try-With-Resources:** Always wrap AutoCloseable engine components in a try-with-resources block, even in tests, to
-  prevent memory leaks in the Virtual Thread carrier threads.
-
-### **Kotlin (DSL Layer)**
-
-* **DslMarker:** Define `@WorkflowDsl` (meta-annotated with `@DslMarker`) and apply it to all Builder classes.
-* **Scope Isolation:** This prevents **Scope Leakage**, ensuring that nested builders cannot access methods from parent
-  scopes incorrectly.
-    * *Example:* An `agent { ... }` block should not be able to call `node { ... }` from the parent graph.
-* **Builder Pattern:** Annotate `WorkflowBuilder`, `GraphBuilder`, and `NodeBuilder` with `@WorkflowDsl` to enforce this
-  boundary.
-* **Context Receivers:** Use context receivers where appropriate for cleaner DSL building logic.
-
----
-
-## Testing Integrity
-
-* **Unit Tests:** Must be pure JVM and use `StubAgentProvider` to avoid API costs and network latency.
-* **Integration Tests:** Use `@QuarkusTest` for server-side logic and verify native-image compatibility with
-  `-Dquarkus.native.enabled=true`.
-* **Assertions:** Use **AssertJ** for fluent, readable assertions.
+- Unit: pure JVM, `StubAgentProvider` only — no network, no API cost.
+- Integration: `@QuarkusTest`.
+- Assertions: AssertJ.

--- a/.claude/rules/20-native-safety.md
+++ b/.claude/rules/20-native-safety.md
@@ -1,119 +1,20 @@
 # 20-native-safety.md
 
-# GraalVM Native Image
+# GraalVM Native Image — Always-On Invariants
 
-The server is deployed as a GraalVM native image via Quarkus. All server code — and any dependency it pulls in — must be
-native-image safe. See
-the [hensu-core Developer Guide](../../docs/developer-guide-core.md#graalvm-native-image-constraints) for the
-foundational rules (no reflection, no classpath scanning, no dynamic proxies, no runtime bytecode generation). This
-section covers **server-specific** concerns.
+The `hensu-server` binary is a GraalVM native image built via Quarkus. These invariants apply to **every** code change in a server-reachable module. Violating them silently breaks the native build.
 
-## How Quarkus Changes the Picture
+## Invariants
 
-Quarkus performs heavy build-time processing that relaxes some raw GraalVM constraints:
+1. **No reflection** — `Class.forName`, `Method.invoke`, `Constructor.newInstance` are forbidden outside explicitly registered entries in `reflect-config.json`.
+2. **No classpath scanning, no dynamic proxies, no runtime bytecode generation.**
+3. **No `ThreadLocal`** — use `ScopedValue` (see `10-java-standards.md` §Security).
+4. **No reflection-based JSON binding in `hensu-core`** — tree-model only (`ObjectMapper.readTree` / `writeValueAsString`).
+5. **No dynamic class loading inside `@Produces`** — producers must instantiate concrete types.
+6. **Do not override versions managed by the Quarkus BOM** — mismatches cause subtle native failures.
 
-| Feature                            | Raw GraalVM                | With Quarkus                                               |
-|------------------------------------|----------------------------|------------------------------------------------------------|
-| CDI injection (`@Inject`)          | Requires reflection config | Works — Quarkus resolves beans at build time (ArC)         |
-| `@ConfigProperty`                  | Requires reflection config | Works — processed at build time                            |
-| JAX-RS resources (`@Path`, `@GET`) | Requires reflection config | Works — REST layer is build-time wired                     |
-| Jackson `@JsonProperty` on DTOs    | Requires reflection config | Works — `quarkus-jackson` registers metadata               |
-| `ServiceLoader`                    | Fails at runtime           | Works — Quarkus scans `META-INF/services` at build time    |
-| LangChain4j AI services            | Requires reflection config | Works — `quarkus-langchain4j` extensions register metadata |
+Safe within Quarkus-managed code (build-time processed, no action needed): `@Inject`, `@Produces`, `@ConfigProperty`, JAX-RS annotations, Jackson `@JsonProperty` on DTOs, Mutiny `Uni`/`Multi`, `ServiceLoader` via `META-INF/services`.
 
-**Key insight**: Within Quarkus-managed code, standard annotations and CDI work normally. The constraints only bite when
-you introduce code that Quarkus doesn't know about — custom reflection, third-party libraries without Quarkus
-extensions, or `hensu-core` internals that bypass the framework.
+## Procedural guidance — loaded on demand
 
-## Adding New Dependencies
-
-When adding a new library to `hensu-server`:
-
-1. **Check if a Quarkus extension exists.** Search [extensions catalog](https://quarkus.io/extensions/) first.
-   Extensions provide build-time metadata, so you get native-image support automatically.
-
-2. **If an extension exists**, add the Quarkus extension (not the raw library):
-   ```kotlin
-   // build.gradle.kts
-   implementation("io.quarkus:quarkus-my-library")  // Quarkus extension
-   // NOT: implementation("org.example:my-library")  // raw library
-   ```
-
-3. **If no extension exists**, you must verify native-image compatibility:
-    - Run `./gradlew hensu-server:build -Dquarkus.native.enabled=true -Dquarkus.package.type=native`
-    - Test the binary: `./hensu-server/build/hensu-server-*-runner`
-    - If it fails with `ClassNotFoundException` or `NoSuchMethodException`, add reflection configuration:
-      ```json
-      // src/main/resources/reflect-config.json
-      [
-        {
-          "name": "com.example.SomeClass",
-          "allDeclaredConstructors": true,
-          "allPublicMethods": true
-        }
-      ]
-      ```
-
-4. **Pin the version to match Quarkus BOM.** If the library is managed by the Quarkus BOM (e.g., Jackson, Vert.x), do
-   not override the version. Mismatched versions cause subtle native-image failures.
-
-## CDI Producers and Native Image
-
-CDI producers in `ServerConfiguration` are native-image safe because Quarkus processes them at build time. Follow these
-patterns:
-
-```java
-// SAFE — Quarkus resolves this at build time
-@Produces
-@Singleton
-public WorkflowExecutor workflowExecutor(HensuEnvironment env) {
-    return env.getWorkflowExecutor();
-}
-
-// SAFE — concrete instantiation
-@Produces
-@Singleton
-public WorkflowRepository workflowRepository() {
-    return new InMemoryWorkflowRepository();
-}
-
-// UNSAFE — dynamic class loading in a producer
-@Produces
-@Singleton
-public Object dynamicBean() {
-    return Class.forName(config.getClassName()).newInstance();  // fails in native
-}
-```
-
-### Server-Specific Notes
-
-**Mutiny reactive types are safe.** `Uni`, `Multi`, `BroadcastProcessor` all work in native image — Quarkus handles
-their registration.
-
-**MCP JSON-RPC uses explicit Jackson.** The `JsonRpc` class uses `ObjectMapper` directly with `readTree`/
-`writeValueAsString` — no reflection-based deserialization. This is intentionally safe for native image.
-
-### Verifying Native Image Compatibility
-
-```bash
-# Full native build (slow — run before releases, not on every change)
-./gradlew hensu-server:build -Dquarkus.native.enabled=true -Dquarkus.package.type=native
-
-# Quick JVM-mode test (catches most issues except native-specific ones)
-./gradlew hensu-server:test
-
-# Native integration tests
-./gradlew hensu-server:test -Dquarkus.test.native-image-profile=true
-```
-
-### Quick Reference (Server-Specific)
-
-| Pattern                                             | Safe  | Notes                                     |
-|-----------------------------------------------------|-------|-------------------------------------------|
-| `@Inject` / `@Produces`                             | Yes   | Quarkus ArC — build-time CDI              |
-| `@ConfigProperty`                                   | Yes   | Build-time processed                      |
-| Quarkus extensions                                  | Yes   | Provide native metadata                   |
-| Raw third-party libs                                | Maybe | Need `reflect-config.json` if reflective  |
-| `ObjectMapper.readTree()`                           | Yes   | No reflection — tree-model parsing        |
-| `new ObjectMapper().readValue(json, MyClass.class)` | Maybe | Needs registration unless Quarkus-managed |
-| Mutiny `Uni`/`Multi`                                | Yes   | Quarkus-managed                           |
+When adding a dependency, writing a new CDI producer, authoring `reflect-config.json`, or verifying a native build, invoke the **`native-image-check`** skill. It carries the decision ladder, commands, examples, and background reading — no need to keep them in session context.

--- a/.claude/skills/javadoc/SKILL.md
+++ b/.claude/skills/javadoc/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: javadoc
+description: Use when writing or editing Javadoc/KDoc on public APIs in hensu-core, hensu-dsl, hensu-serialization, or hensu-server. Covers Markdown Javadoc (`///`) syntax for Java 25, required tag order, `{@link}` usage, `@since` policy, sealed-hierarchy documentation, and the "documentation as structured metadata" philosophy. Triggers on phrases like "add javadoc", "document this API", "write kdoc", or any edit that adds/modifies `///`, `/** */`, or `/** */` doc comments on public types, methods, or fields.
+---
+
+# Javadoc Authoring Skill
+
+Authoritative source: [`docs/javadoc-guide.md`](../../../docs/javadoc-guide.md).
+
+## Workflow
+
+1. **Read the full guide** — `docs/javadoc-guide.md` contains the tag tables, ordering rules, and module-specific conventions. Do not attempt to author Javadoc from memory; the guide is the single source of truth.
+2. **Identify the surface** — public class, interface, method, field, or package. Non-public members do not require Javadoc unless they are part of an SPI.
+3. **Use Markdown Javadoc (`///`)** for all new Java 23+ code. Use KDoc (`/** */`) for Kotlin.
+4. **Apply the required tag set** for the surface type (see §3 of the guide).
+5. **Verify with `./gradlew javadoc`** before declaring done on documentation-only changes.
+
+## Hard rules (do not violate)
+
+- If a machine cannot parse the doc block, it is incomplete.
+- Every public method documents `@param`, `@return`, and `@throws` where applicable — no exceptions.
+- Sealed hierarchies list all permitted subtypes in the parent Javadoc.
+- No legacy HTML (`<p>`, `<ul>`, `<b>`) in new `///` blocks — use Markdown equivalents.
+
+## When in doubt
+
+Re-read the relevant section of `docs/javadoc-guide.md` rather than guessing. The guide's tag tables are exhaustive.

--- a/.claude/skills/native-image-check/SKILL.md
+++ b/.claude/skills/native-image-check/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: native-image-check
+description: Use when adding a new dependency to hensu-server, writing a new CDI `@Produces` method, introducing reflection, dynamic proxies, classpath scanning, or `ServiceLoader`, or preparing a release that needs native-image verification. Covers the Quarkus-extension-first decision, `reflect-config.json` authoring, BOM version pinning, CDI producer patterns, Mutiny/MCP safety notes, and the native build/verify commands. Triggers on phrases like "add dependency", "native build", "graalvm", "quarkus extension", "reflect-config", "Class.forName", or any edit to `build.gradle.kts` that adds an `implementation(...)` line in a server-side module.
+---
+
+# GraalVM Native Image Safety Skill
+
+Background reading: [hensu-core Developer Guide — GraalVM Native Image Constraints](../../../docs/developer-guide-core.md#graalvm-native-image-constraints).
+
+The always-on invariants (no reflection, no `ThreadLocal`, no classpath scanning, etc.) live in `.claude/rules/20-native-safety.md`. This skill covers the **procedural** guidance — the how and when.
+
+---
+
+## How Quarkus changes the picture
+
+Quarkus performs heavy build-time processing that relaxes some raw GraalVM constraints:
+
+| Feature                            | Raw GraalVM                | With Quarkus                                               |
+|------------------------------------|----------------------------|------------------------------------------------------------|
+| CDI injection (`@Inject`)          | Requires reflection config | Works — Quarkus resolves beans at build time (ArC)         |
+| `@ConfigProperty`                  | Requires reflection config | Works — processed at build time                            |
+| JAX-RS resources (`@Path`, `@GET`) | Requires reflection config | Works — REST layer is build-time wired                     |
+| Jackson `@JsonProperty` on DTOs    | Requires reflection config | Works — `quarkus-jackson` registers metadata               |
+| `ServiceLoader`                    | Fails at runtime           | Works — Quarkus scans `META-INF/services` at build time    |
+| LangChain4j AI services            | Requires reflection config | Works — `quarkus-langchain4j` extensions register metadata |
+
+**Key insight:** within Quarkus-managed code, standard annotations and CDI work normally. Constraints only bite when you introduce code Quarkus doesn't know about — custom reflection, third-party libraries without Quarkus extensions, or `hensu-core` internals that bypass the framework.
+
+---
+
+## Decision ladder for adding a dependency
+
+1. **Does a Quarkus extension exist?** Search https://quarkus.io/extensions/ first. If yes, add the extension (not the raw library):
+   ```kotlin
+   // build.gradle.kts
+   implementation("io.quarkus:quarkus-my-library")  // Quarkus extension
+   // NOT: implementation("org.example:my-library")  // raw library
+   ```
+2. **Is it managed by the Quarkus BOM?** If yes, do not override the version — mismatches cause subtle native failures.
+3. **No extension, not in BOM** → you own the native-image risk. Proceed to verification below. If the binary fails with `ClassNotFoundException` or `NoSuchMethodException`, add an entry to `hensu-server/src/main/resources/reflect-config.json`:
+   ```json
+   [
+     {
+       "name": "com.example.SomeClass",
+       "allDeclaredConstructors": true,
+       "allPublicMethods": true
+     }
+   ]
+   ```
+
+---
+
+## CDI producer patterns
+
+```java
+// SAFE — Quarkus resolves this at build time
+@Produces
+@Singleton
+public WorkflowExecutor workflowExecutor(HensuEnvironment env) {
+    return env.getWorkflowExecutor();
+}
+
+// SAFE — concrete instantiation
+@Produces
+@Singleton
+public WorkflowRepository workflowRepository() {
+    return new InMemoryWorkflowRepository();
+}
+
+// UNSAFE — dynamic class loading in a producer
+@Produces
+@Singleton
+public Object dynamicBean() {
+    return Class.forName(config.getClassName()).newInstance();  // fails in native
+}
+```
+
+---
+
+## Server-specific notes
+
+- **Mutiny reactive types are safe.** `Uni`, `Multi`, `BroadcastProcessor` all work in native image — Quarkus handles registration.
+- **MCP JSON-RPC uses explicit Jackson.** `JsonRpc` uses `ObjectMapper` directly with `readTree`/`writeValueAsString` — no reflection-based deserialization. Intentionally safe for native image.
+
+---
+
+## Verification commands
+
+```bash
+# Full native build (slow — run before releases, not on every change)
+./gradlew hensu-server:build -Dquarkus.native.enabled=true -Dquarkus.package.type=native
+
+# Run the produced binary
+./hensu-server/build/hensu-server-*-runner
+
+# Quick JVM-mode test (catches most issues except native-specific ones)
+./gradlew hensu-server:test
+
+# Native integration tests
+./gradlew hensu-server:test -Dquarkus.test.native-image-profile=true
+```
+
+### When to run the full native build
+
+- Before tagging a release.
+- After adding any non-Quarkus-extension library to a server module.
+- After adding or modifying `reflect-config.json`, `resource-config.json`, or `native-image.properties`.
+
+Skip the full native build for pure JVM logic changes — `./gradlew hensu-server:test` is enough for iteration.
+
+---
+
+## Quick reference
+
+| Pattern                                             | Safe  | Notes                                     |
+|-----------------------------------------------------|-------|-------------------------------------------|
+| `@Inject` / `@Produces`                             | Yes   | Quarkus ArC — build-time CDI              |
+| `@ConfigProperty`                                   | Yes   | Build-time processed                      |
+| Quarkus extensions                                  | Yes   | Provide native metadata                   |
+| Raw third-party libs                                | Maybe | Need `reflect-config.json` if reflective  |
+| `ObjectMapper.readTree()`                           | Yes   | No reflection — tree-model parsing        |
+| `new ObjectMapper().readValue(json, MyClass.class)` | Maybe | Needs registration unless Quarkus-managed |
+| Mutiny `Uni`/`Multi`                                | Yes   | Quarkus-managed                           |

--- a/.claude/skills/visual-style/SKILL.md
+++ b/.claude/skills/visual-style/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: visual-style
+description: Use when producing or editing diagrams, charts, badges, or ASCII architecture art anywhere in the Hensu repo — Mermaid blocks in `.md` files, ASCII line-drawings in `///` Javadoc or `/** */` KDoc, README badges, or any rendered visual. Enforces the monochrome dark-mode Mermaid palette, the ASCII character palette (`+`, `—`, `│`, no rounded corners, no emojis in boxes), and badge color conventions. Triggers on phrases like "add a diagram", "draw the architecture", "update the badge", "mermaid", "ascii diagram", or any edit that adds/modifies ```` ```mermaid ```` fences, ASCII box art, or shields.io badge URLs.
+---
+
+# Visual Style Skill
+
+Authoritative source: [`docs/visual-style-guide.md`](../../../docs/visual-style-guide.md).
+
+## Workflow
+
+1. **Read the full guide** — `docs/visual-style-guide.md` has the exact character palette, Mermaid theme variables, and badge color tokens. Do not author visuals from memory.
+2. **Pick the right medium:**
+    - **`.java` / `.kt` files** → ASCII line-draw (Part 1 of the guide)
+    - **`.md` files** → Mermaid (Part 2)
+    - **Badges** → shields.io with the project palette (Part 3)
+3. **Apply the palette verbatim.** Copy theme variables and color tokens from the guide — do not approximate.
+4. **Verify rendering** — preview Mermaid blocks on GitHub or a Mermaid live editor before committing.
+
+## Hard rules
+
+- **ASCII:** `+` for corners, `—` (em dash U+2014) for horizontals, `│` (U+2502) for verticals. **Prohibited:** `┌`, `└`, `╭`, `╰`, plain `-`, plain `|`, emojis inside boxes.
+- **Mermaid:** dark mode, monochrome grays, one accent color, thin strokes. No rainbow palettes.
+- **Badges:** shields.io only, project palette only, stable left-label wording.
+
+## When in doubt
+
+Re-read the relevant Part of `docs/visual-style-guide.md`. The character palette and color tokens are not negotiable — consistency across the repo is the whole point.

--- a/.cursor/rules/00-master.mdc
+++ b/.cursor/rules/00-master.mdc
@@ -15,7 +15,12 @@ You are the Lead Software Engineer for Hensu, an orchestration engine for AI wor
 
 MANDATORY: Before every session:
 - You MUST read and adhere to the standards in AGENTS.md.
-- Adhere to the "Model Coordination" in `01-model-coordination.mdc`.
-- Adhere to the "GraalVM Native Image" in `10-java-standards.mdc`.
-- Adhere to the "Hensu Java & Kotlin Standards" in `20-native-safety.mdc`.
-- Document all public APIs following the [Javadoc Guide](../../docs/javadoc-guide.md).
+- Adhere to the "Model Coordination" in `01-model-coordination.md`.
+- Adhere to the "Chat Density Protocol" in `02-output-density.md` (dense chat, prose for all written artifacts).
+- Adhere to the "Hensu Java & Kotlin Standards" in `10-java-standards.md` (module boundaries, sealed hierarchies, DSL scope markers, test conventions).
+- Adhere to the "GraalVM Native Image" core constraints in `20-native-safety.md` (no reflection, no ThreadLocal, no classpath scanning).
+
+Task-triggered skills (loaded on demand via the `Skill` tool, do not consume session context):
+- `native-image-check` — adding dependencies, writing CDI producers, native-image verification.
+- `visual-style` — diagrams, Mermaid blocks, ASCII architecture art, badges.
+- `javadoc` — authoring or editing Javadoc/KDoc on public APIs.

--- a/.cursor/rules/01-model-coordination.mdc
+++ b/.cursor/rules/01-model-coordination.mdc
@@ -4,76 +4,40 @@ globs: **/*
 alwaysApply: true
 ---
 
-# Model Coordination & Persistence Rules
+## Mode Auto-Detection
 
-## 0. Mode Detection (Auto-Fallback)
+Ping `mcp__gemini__ping` at session start.
 
-**This section runs first, every session. No developer action required.**
+- **Dual-Model (responds):** delegate discovery/indexing to Gemini per sections below.
+- **Single-Model (absent or fails):** skip all `mcp__gemini__*` calls silently. Use `Glob`/`Grep` for discovery; Claude self-reviews dependencies inline.
 
-At session start, probe for Gemini MCP availability by attempting a ping via the Gemini MCP tool.
+## Persona & Collaboration (Dual-Model)
 
-| Result                        | Active Mode           |
-|-------------------------------|-----------------------|
-| Tool exists and responds      | **Dual-Model Mode**   |
-| Tool absent or call rejected  | **Single-Model Mode** |
+- **Claude — Lead Architect & Implementer.** Owns core logic, architectural integrity, final edits. Token-poor: never ingest raw files when Gemini can pre-digest them.
+- **Gemini — Cynical Researcher / Indexer.** 1M-window scan, noise reduction, blunt dependency reviews. Must discard anything less than 100% relevant to the task.
 
-### Dual-Model Mode (Gemini MCP available)
+## Model Routing
 
-Follow sections 1–5 below as written. Claude/Cursor is Lead Implementer; Gemini is Cynical Researcher/Indexer.
+- **Discovery / Indexing:** `gemini-3.1-flash-lite-preview`
+- **Logic / Refactoring:** `gemini-3.1-pro-preview`
 
-### Single-Model Mode (Gemini MCP not available)
+## Discovery Rule (Dual-Model)
 
-The main model acts as both Lead Implementer **and** Researcher. Adjust the protocol:
+- **Prohibited:** `Glob`, `Grep`, `Bash`-based file discovery, recursive `ls`.
+- Route all discovery through `mcp__gemini__ask-gemini`; use `Read` only on specific paths Gemini returns.
 
-- **Skip** all Gemini MCP calls — do not error, do not prompt the developer.
-- **Lift the grep/ls prohibition** from §2: use native search tools (Glob, Grep) for discovery.
-- **§1 Gemini persona** is dormant — the main model self-reviews dependencies for virtual-thread and native-image safety.
-- **§5 Cynical Review** is performed inline before accepting a new dependency.
-- All other rules (AGENTS.md warm-start, Memory MCP, pathing) remain active.
+## Persistence & State
 
-> **Developer note:** To enable Dual-Model Mode, plug the `gemini-mcp` server into your Cursor MCP config.
-> Nothing else changes — the rules self-adapt.
+- Warm-start every session with `AGENTS.md`.
+- Append architectural decisions to `AGENTS.md` immediately — do not keep them in chat history.
+- Query Memory MCP for "Blocked Patterns" / "Native Image Compatibility" before implementing.
 
----
+## Dependency Vetting Checklist
 
-## 1. Persona & Collaboration
+When adding any new dependency, verify:
+1. **Virtual-thread safe:** no `synchronized` blocks that pin carrier threads.
+2. **Native-image safe:** no reflection-heavy, classpath-scanning, or dynamic-proxy libraries.
 
-- **Claude (Lead Architect & Implementer):** - **Focus:** Core logic, architectural integrity, and final code execution.
-    - **Constraint:** Maintain "Token-Poverty" mindset. Never ingest raw files if Gemini can provide a distilled
-      summary.
-- **Gemini (Cynical Researcher/Indexer):**
-    - **Focus:** High-context scanning (1M window), noise reduction, and "Bro-opinion" technical reviews.
-    - **Constraint:** Use `gemini-3.1-flash-lite-preview` for indexing. Your goal is to kill noise. If a code block isn't 100%
-      relevant to the specific task, discard it.
+## Pathing
 
-## 2. Token-Efficient Research Protocol (The "Pre-Filter" Hack)
-
-- **The Protocol:** For any task, Claude must first trigger Gemini with the following instruction:
-  > "Act as the Cynical Researcher. Scan the 1M context for [Task]. Strip boilerplate, identify logic 'hot spots,' and
-  provide a minimalist index of only the essential snippets with a blunt one-sentence opinion on each."
-- **Model Routing:**
-    - **Discovery/Indexing:** `gemini-3.1-flash-lite-preview`.
-    - **Complex Logic/Refactoring:** `gemini-3.1-pro-preview` (or latest Pro model).
-- **Prohibited:** No `grep` or recursive `ls`. These are legacy "blind" tools. Use Gemini's semantic understanding to
-  find what matters.
-
-## 3. Shared Persistence (AGENTS.md)
-
-- **Source of Truth:** `AGENTS.md` is the "Hensu Brain."
-- **Warm Start:** Every session begins with a `read_file` of `AGENTS.md`.
-- **Atomic Commits:** When an architectural decision is finalized (e.g., SSE multi-tenancy rules), use `save_memory` or
-  append to `AGENTS.md` immediately. Do not keep decisions only in chat history.
-
-## 4. Knowledge Graph (Memory MCP)
-
-- **Relation Mapping:** Use the `memory` MCP server to map dependencies (e.g., "Hensu-Server *consumes* Hensu-DSL").
-- **Constraint Check:** Before implementing, query Memory for "Blocked Patterns" or "Native Image Compatibility" notes
-  recorded in previous sessions.
-
-## 5. Technical Guardrails (The "Hensu" Stack)
-
-- **Stack:** Java 25 (Project Loom) / Kotlin 2.x / Quarkus.
-- **Cynical Review:** Gemini must verify all new dependencies for:
-    1. **Virtual Thread Friendly:** No synchronized blocks pinning threads.
-    2. **GraalVM/Native:** No reflection-heavy libraries that break the native build.
-- **Pathing:** Use `$(pwd)/path` for all tool calls to prevent context drift.
+Always use `$(pwd)/path` in tool calls to prevent context drift.

--- a/.cursor/rules/02-output-density.mdc
+++ b/.cursor/rules/02-output-density.mdc
@@ -1,0 +1,52 @@
+---
+description: Chat Density Protocol — strip fluff from assistant chat only; keep prose for all written artifacts.
+globs: **/*
+alwaysApply: true
+---
+
+Applies ONLY to assistant chat replies in this session. Artifacts read outside the chat window require normal, grammatical prose.
+
+## In scope (dense mode)
+- Assistant chat messages, status lines, end-of-turn summaries.
+- Clarifying questions to the user.
+- Inline tool-use narration.
+
+## Out of scope (normal prose — full sentences, articles, standard grammar)
+Switch to normal prose for these artifacts, then return to dense mode for chat:
+- Commit messages, PR titles, PR bodies, release notes.
+- Javadoc, KDoc, code comments (see `javadoc` skill).
+- Markdown docs under `docs/`, `README.md`, `AGENTS.md`, rule files.
+- Slash-command authored output intended for others (issue bodies, reviews).
+- Error messages, log strings, user-facing product copy.
+- Code identifiers, string literals, test descriptions.
+
+## Dense-mode rules (chat only)
+- No pleasantries ("Sure!", "Great question", "Happy to help").
+- No hedging without evidence.
+- No recapping user inputs or past actions.
+- No trailing summaries unless requested (end-of-turn = ≤1 sentence).
+- Use imperative mood for actions.
+- Use bulleted lists for ≥3 parallel items.
+- Drop articles (a/an/the) in bullets, status lines, and headings if clarity is preserved. Keep them in full sentences.
+- No filler transitions ("Now,", "So,", "Basically,").
+- Limit tool-use meta-narration to ≤1 intent sentence.
+- Use arrow notation (`X → Y`) for causal chains.
+- For ambiguous intent: ask one short question, no preamble.
+
+### Example
+
+Verbose (reject):
+> Great question! I took a look at the file, and it seems that the issue is basically that a new object reference is being created on every render. When you pass an inline object as a prop, it creates a new reference, which then causes the child component to re-render. So, you'll want to wrap it in `useMemo` to fix this.
+
+Dense (accept):
+> Inline obj prop → new ref each render → child re-renders. Wrap in `useMemo`.
+
+## Drop dense mode for
+Revert to full prose when terseness risks harm or ambiguity:
+- Security warnings and threat-model explanations.
+- Confirmation prompts before irreversible or destructive actions (force push, `rm -rf`, dropping tables, deleting branches).
+- Multi-step sequences where fragment ordering or dropped articles could change the meaning or lead to misexecution.
+- When the user explicitly asks for clarification of something already stated tersely.
+
+## Override
+Honor per-turn verbose requests ("explain in detail", "walk me through"); revert next turn.

--- a/.cursor/rules/10-java-standards.mdc
+++ b/.cursor/rules/10-java-standards.mdc
@@ -3,83 +3,31 @@ description: Coding standards for Java 25 and Kotlin DSL, focusing on ScopedValu
 globs: **/*.{java,kt}
 ---
 
-# 10: Java & Kotlin Standards
+Generic SOLID/KISS/YAGNI/DRY apply silently. Only project-specific rules below.
 
-This document defines the strict coding standards for the Hensu engine. Adherence ensures
-**GraalVM native-image safety** and **multi-tenant isolation**.
+## Module boundaries
 
----
+- `hensu-core` has **zero third-party deps** beyond JDK 25. No vendor SDKs, no vendor `if/else`.
+- All `Agent` impls are interchangeable (Liskov). Capability differences go through narrow interfaces like `ToolCapable`, `Streamable` — never a God interface, never vendor-sniffing in the orchestration loop.
+- Shared constants/schema live in `hensu-core` so CLI and Server speak the same language.
+- Logic duplicated between `hensu-core` and `hensu-server` → extract to a shared util/base provider.
 
-## Engineering Philosophy (SOLID, KISS, YAGNI, DRY)
+## Concurrency
 
-You must justify every architectural change against these principles:
+- See `20-native-safety.md` §3 for the `ThreadLocal` ban and `ScopedValue` pattern.
+- Verify no data bleeds between parallel workflow nodes during fan-out/fan-in.
 
-### SOLID Protocol
+## Domain model
 
-* **S (Single Responsibility):** One class, one reason to change. Split executors from coordinators.
-* **O (Open/Closed):** Extend via interfaces. Do not modify the core orchestration loop for new providers.
-* **L (Liskov Substitution):** All `Agent` implementations must be interchangeable. No vendor-specific "if/else" logic
-  in the Core.
-* **I (Interface Segregation):** Favor many specific interfaces (e.g., `ToolCapable`, `Streamable`) over one "God"
-  interface.
-* **D (Dependency Inversion):** High-level logic must depend on abstractions. No direct dependencies on vendor SDKs in
-  `hensu-core`.
+- Domain results → `sealed interface` (e.g. `ExecutionResult`, `TransitionStatus`), consumed via `switch` pattern matching.
+- All domain models immutable; construct via `hensu-serialization` builder mixins.
 
-### KISS & YAGNI
+## Kotlin DSL
 
-* **Zero-Dependency Core:** No new libraries in `hensu-core` unless standard JVM (Java 25) is insufficient.
-* **Feature Restraint:** Do not build "future-proof" abstractions. Implement only what is required for the current
-  logic.
+- `@WorkflowDsl` (meta `@DslMarker`) on `WorkflowBuilder`, `GraphBuilder`, `NodeBuilder` — prevents scope leakage (an `agent { }` block must not see parent `node { }`).
 
-### DRY (Don't Repeat Yourself) & Single Source of Truth
+## Tests
 
-* **Logic Duplication:** If the same orchestration logic appears in both `hensu-core` and `hensu-server`, it must be
-  extracted into a shared internal utility or a base provider.
-* **Core Constants:** Do not hardcode strings for repeated constants. Use a shared `Constants` or `Schema` object
-  in the `core` module to ensure the CLI and Server speak the same language.
-* **The "Rule of Three":** Do not abstract code the first time it is repeated. Wait for the third occurrence to ensure
-  the abstraction is actually reusable and not a "leaky" coupling.
-* **SSOT (Single Source of Truth):** The `AGENTS.md` and the module rules are the SSOT for project intent.
-
----
-
-## Security: ScopedValues Over ThreadLocal
-
-To support high-concurrency Virtual Threads (Project Loom) and safe SaaS deployment, **`ScopedValues`** are mandatory
-for context propagation.
-
-* **RULE:** Never use `ThreadLocal`. It leads to memory leaks and context pollution in Virtual Thread pools.
-* **PATTERN:** Use `ScopedValue.where(CONTEXT, value).run(() -> { ... })` for passing tenant IDs, security tokens, and
-  workflow state.
-* **ISOLATION:** Rigorously verify that no data "bleeds" between workflow nodes during parallel execution.
-
----
-
-## Language Standards
-
-Hensu leverages the latest JVM features to reduce boilerplate and increase type safety.
-
-### **Java 25+ (Core & Server)**
-
-* **Sealed Hierarchies:** Use `sealed interface` for all domain results (e.g., `ExecutionResult`, `TransitionStatus`).
-* **Pattern Matching:** Use `switch` expression pattern matching for processing node types and workflow events.
-* **Immutability:** All domain models must be immutable. Use the builder pattern provided by the `hensu-serialization`
-  mixins.
-* **Try-With-Resources:** Always wrap AutoCloseable engine components in a try-with-resources block, even in tests, to
-  prevent memory leaks in the Virtual Thread carrier threads.
-
-### **Kotlin (DSL Layer)**
-* **DslMarker:** Define `@WorkflowDsl` (meta-annotated with `@DslMarker`) and apply it to all Builder classes.
-* **Scope Isolation:** This prevents **Scope Leakage**, ensuring that nested builders cannot access methods from parent scopes incorrectly.
-  * *Example:* An `agent { ... }` block should not be able to call `node { ... }` from the parent graph.
-* **Builder Pattern:** Annotate `WorkflowBuilder`, `GraphBuilder`, and `NodeBuilder` with `@WorkflowDsl` to enforce this boundary.
-* **Context Receivers:** Use context receivers where appropriate for cleaner DSL building logic.
-
----
-
-## Testing Integrity
-
-* **Unit Tests:** Must be pure JVM and use `StubAgentProvider` to avoid API costs and network latency.
-* **Integration Tests:** Use `@QuarkusTest` for server-side logic and verify native-image compatibility with
-  `-Dquarkus.native.enabled=true`.
-* **Assertions:** Use **AssertJ** for fluent, readable assertions.
+- Unit: pure JVM, `StubAgentProvider` only — no network, no API cost.
+- Integration: `@QuarkusTest`.
+- Assertions: AssertJ.

--- a/.cursor/rules/20-native-safety.mdc
+++ b/.cursor/rules/20-native-safety.mdc
@@ -3,120 +3,21 @@ description: GraalVM and Quarkus-native compatibility rules. Prevents runtime re
 globs: hensu-{server,cli,core}/**/*
 ---
 
-# 20: Native-Image Safety
+# GraalVM Native Image — Always-On Invariants
 
-The server is deployed as a GraalVM native image via Quarkus. All server code — and any dependency it pulls in — must be
-native-image safe. See
-the [hensu-core Developer Guide](../../docs/developer-guide-core.md#graalvm-native-image-constraints) for the
-foundational rules (no reflection, no classpath scanning, no dynamic proxies, no runtime bytecode generation). This
-section covers **server-specific** concerns.
+The `hensu-server` binary is a GraalVM native image built via Quarkus. These invariants apply to **every** code change in a server-reachable module. Violating them silently breaks the native build.
 
-## How Quarkus Changes the Picture
+## Invariants
 
-Quarkus performs heavy build-time processing that relaxes some raw GraalVM constraints:
+1. **No reflection** — `Class.forName`, `Method.invoke`, `Constructor.newInstance` are forbidden outside explicitly registered entries in `reflect-config.json`.
+2. **No classpath scanning, no dynamic proxies, no runtime bytecode generation.**
+3. **No `ThreadLocal`** — use `ScopedValue` (see `10-java-standards.md` §Security).
+4. **No reflection-based JSON binding in `hensu-core`** — tree-model only (`ObjectMapper.readTree` / `writeValueAsString`).
+5. **No dynamic class loading inside `@Produces`** — producers must instantiate concrete types.
+6. **Do not override versions managed by the Quarkus BOM** — mismatches cause subtle native failures.
 
-| Feature                            | Raw GraalVM                | With Quarkus                                               |
-|------------------------------------|----------------------------|------------------------------------------------------------|
-| CDI injection (`@Inject`)          | Requires reflection config | Works — Quarkus resolves beans at build time (ArC)         |
-| `@ConfigProperty`                  | Requires reflection config | Works — processed at build time                            |
-| JAX-RS resources (`@Path`, `@GET`) | Requires reflection config | Works — REST layer is build-time wired                     |
-| Jackson `@JsonProperty` on DTOs    | Requires reflection config | Works — `quarkus-jackson` registers metadata               |
-| `ServiceLoader`                    | Fails at runtime           | Works — Quarkus scans `META-INF/services` at build time    |
-| LangChain4j AI services            | Requires reflection config | Works — `quarkus-langchain4j` extensions register metadata |
+Safe within Quarkus-managed code (build-time processed, no action needed): `@Inject`, `@Produces`, `@ConfigProperty`, JAX-RS annotations, Jackson `@JsonProperty` on DTOs, Mutiny `Uni`/`Multi`, `ServiceLoader` via `META-INF/services`.
 
-**Key insight**: Within Quarkus-managed code, standard annotations and CDI work normally. The constraints only bite when
-you introduce code that Quarkus doesn't know about — custom reflection, third-party libraries without Quarkus
-extensions, or `hensu-core` internals that bypass the framework.
+## Procedural guidance — loaded on demand
 
-## Adding New Dependencies
-
-When adding a new library to `hensu-server`:
-
-1. **Check if a Quarkus extension exists.** Search [extensions catalog](https://quarkus.io/extensions/) first.
-   Extensions provide build-time metadata, so you get native-image support automatically.
-
-2. **If an extension exists**, add the Quarkus extension (not the raw library):
-   ```kotlin
-   // build.gradle.kts
-   implementation("io.quarkus:quarkus-my-library")  // Quarkus extension
-   // NOT: implementation("org.example:my-library")  // raw library
-   ```
-
-3. **If no extension exists**, you must verify native-image compatibility:
-    - Run `./gradlew hensu-server:build -Dquarkus.native.enabled=true -Dquarkus.package.type=native`
-    - Test the binary: `./hensu-server/build/hensu-server-*-runner`
-    - If it fails with `ClassNotFoundException` or `NoSuchMethodException`, add reflection configuration:
-      ```json
-      // src/main/resources/reflect-config.json
-      [
-        {
-          "name": "com.example.SomeClass",
-          "allDeclaredConstructors": true,
-          "allPublicMethods": true
-        }
-      ]
-      ```
-
-4. **Pin the version to match Quarkus BOM.** If the library is managed by the Quarkus BOM (e.g., Jackson, Vert.x), do
-   not override the version. Mismatched versions cause subtle native-image failures.
-
-## CDI Producers and Native Image
-
-CDI producers in `ServerConfiguration` are native-image safe because Quarkus processes them at build time. Follow these
-patterns:
-
-```java
-// SAFE — Quarkus resolves this at build time
-@Produces
-@Singleton
-public WorkflowExecutor workflowExecutor(HensuEnvironment env) {
-    return env.getWorkflowExecutor();
-}
-
-// SAFE — concrete instantiation
-@Produces
-@Singleton
-public WorkflowRepository workflowRepository() {
-    return new InMemoryWorkflowRepository();
-}
-
-// UNSAFE — dynamic class loading in a producer
-@Produces
-@Singleton
-public Object dynamicBean() {
-    return Class.forName(config.getClassName()).newInstance();  // fails in native
-}
-```
-
-### Server-Specific Notes
-
-**Mutiny reactive types are safe.** `Uni`, `Multi`, `BroadcastProcessor` all work in native image — Quarkus handles
-their registration.
-
-**MCP JSON-RPC uses explicit Jackson.** The `JsonRpc` class uses `ObjectMapper` directly with `readTree`/
-`writeValueAsString` — no reflection-based deserialization. This is intentionally safe for native image.
-
-### Verifying Native Image Compatibility
-
-```bash
-# Full native build (slow — run before releases, not on every change)
-./gradlew hensu-server:build -Dquarkus.native.enabled=true -Dquarkus.package.type=native
-
-# Quick JVM-mode test (catches most issues except native-specific ones)
-./gradlew hensu-server:test
-
-# Native integration tests
-./gradlew hensu-server:test -Dquarkus.test.native-image-profile=true
-```
-
-### Quick Reference (Server-Specific)
-
-| Pattern                                             | Safe  | Notes                                     |
-|-----------------------------------------------------|-------|-------------------------------------------|
-| `@Inject` / `@Produces`                             | Yes   | Quarkus ArC — build-time CDI              |
-| `@ConfigProperty`                                   | Yes   | Build-time processed                      |
-| Quarkus extensions                                  | Yes   | Provide native metadata                   |
-| Raw third-party libs                                | Maybe | Need `reflect-config.json` if reflective  |
-| `ObjectMapper.readTree()`                           | Yes   | No reflection — tree-model parsing        |
-| `new ObjectMapper().readValue(json, MyClass.class)` | Maybe | Needs registration unless Quarkus-managed |
-| Mutiny `Uni`/`Multi`                                | Yes   | Quarkus-managed                           |
+When adding a dependency, writing a new CDI producer, authoring `reflect-config.json`, or verifying a native build, invoke the **`native-image-check`** skill. It carries the decision ladder, commands, examples, and background reading — no need to keep them in session context.

--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,7 @@ publicKey.pem
 .anthropic/
 .mem/
 /.claude/projects/
+/.claude/tmp/
+
+# Local MCP overrides
+.mcp.local.json

--- a/.mcp.README.md
+++ b/.mcp.README.md
@@ -1,0 +1,68 @@
+# Gemini MCP — Setup
+
+Project-scoped MCP server config lives in `.mcp.json` (auto-loaded by Claude Code).
+
+## Prerequisites
+
+```bash
+# Install Gemini CLI globally
+npm install -g @google/gemini-cli
+
+# Authenticate
+gemini auth login
+
+# Verify
+gemini --version
+```
+
+## Register the MCP server
+
+The repo already ships `.mcp.json` with the NPX-based config (no local install needed):
+
+```json
+{
+  "mcpServers": {
+    "gemini-cli": {
+      "command": "npx",
+      "args": ["-y", "gemini-mcp-tool"]
+    },
+    "memory": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-memory"]
+    }
+  }
+}
+```
+
+Equivalent one-liners if you prefer the CLI:
+
+```bash
+claude mcp add gemini-cli -- npx -y gemini-mcp-tool
+claude mcp add memory -- npx -y @modelcontextprotocol/server-memory
+```
+
+## Verify
+
+Inside Claude Code, run `/mcp` and confirm `gemini-cli` is listed and active.
+
+## Alternative — global install (gemini-cli only)
+
+If `gemini-mcp-tool` is installed globally and you want to skip NPX:
+
+```json
+{
+  "mcpServers": {
+    "gemini-cli": {
+      "command": "gemini-mcp"
+    }
+  }
+}
+```
+
+## Alternative — import from Claude Desktop
+
+If already configured in Claude Desktop:
+
+```bash
+claude mcp add-from-claude-desktop
+```

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "gemini-cli": {
+      "command": "npx",
+      "args": ["-y", "gemini-mcp-tool"]
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,437 +1,53 @@
 # AGENTS.md: Hensu™ Project Operational Manual
 
-- Project Status: Pre-Beta
-- Lead Developer: @alxsuv
-- Standard: AGENTS.md v1.2 (2026)
+Single Source of Truth for all AI coding agents. You MUST read this before proposing changes or executing commands.
 
-This file is the Single Source of Truth for all AI coding agents (Claude, Cursor, etc.). You MUST read this before
-proposing changes or executing commands.
+Guides live in [docs/](docs/) — read on demand (core/server developer guides, DSL reference, architecture, javadoc standards).
 
----
+## Build
 
-## Documentation
+Standard Gradle wrapper (`./gradlew build`, `./gradlew test`, `./gradlew <module>:test --tests "FooTest"`, `./gradlew hensu-server:quarkusDev`).
 
-| Document                                                 | Description                                    |
-|----------------------------------------------------------|------------------------------------------------|
-| [Core Developer Guide](docs/developer-guide-core.md)     | API usage, adapters, extension points, testing |
-| [DSL Reference](docs/dsl-reference.md)                   | Complete Kotlin DSL syntax and examples        |
-| [Javadoc Guide](docs/javadoc-guide.md)                   | Documentation standards                        |
-| [Unified Architecture](docs/unified-architecture.md)     | Unified Architecture Vision                    |
-| [Server Developer Guide](docs/developer-guide-server.md) | Server development patterns                    |
+Modules: `hensu-core`, `hensu-dsl`, `hensu-serialization`, `hensu-cli`, `hensu-server`, `hensu-langchain4j-adapter`.
+Dependency flow: `cli → dsl → core`, `cli → serialization → core`, `server → serialization → core`, `langchain4j-adapter → core`.
 
-## Build Commands
+## Architecture
 
-```bash
-# Build all modules
-./gradlew build
+Hensu is a modular AI workflow engine on Java 25 + Kotlin DSL. Core design principle: **zero external dependencies in `hensu-core`** — all AI provider integrations go through the `AgentProvider` interface, wired explicitly via `HensuFactory.builder().agentProviders(...)`. No classpath scanning, GraalVM-native-safe.
 
-# Build specific module
-./gradlew hensu-core:build
-./gradlew hensu-serialization:build
-./gradlew hensu-cli:build
-./gradlew hensu-server:build
-
-# Run all tests
-./gradlew test
-
-# Run tests for specific module
-./gradlew hensu-core:test
-./gradlew hensu-serialization:test
-./gradlew hensu-server:test
-
-# Run a single test class
-./gradlew hensu-core:test --tests "RubricEngineTest"
-
-# Run CLI in Quarkus dev mode
-./gradlew hensu-cli:quarkusDev
-
-# Run server in Quarkus dev mode
-./gradlew hensu-server:quarkusDev
-```
-
-## Architecture Overview
-
-Hensu is a modular AI workflow engine built on Java 25 with Kotlin DSL support.
-
-Key features:
-
-- Declarative Workflow Configuration - Define workflows declaratively with an intuitive Kotlin DSL
-- Extensible Node System - Create custom nodes to extend workflow capabilities when needed
-- Complex Workflows - Undirected flows, loops, forks, parallel execution, consensus-based decisions
-- Rubric-Driven Quality Gates - Evaluate outputs against defined criteria with score-based routing
-- Human Review Integration - Optional or required review at any workflow step
-- Multi-Provider Support - Claude, GPT, Gemini, DeepSeek via pluggable adapters
-- Pause / Resume - Workflows can pause at checkpoints and resume (potentially on a different server instance)
-- Sub-Workflows - Hierarchical composition via `SubWorkflowNode` with input/output mapping
-- Time-Travel Debugging - Execution history with backtracking support
-- Zero Lock-In - Self-hosted, pure code, no proprietary formats
-
-The core module design principle is **zero external dependencies** — all AI provider integrations happen through the
-`AgentProvider` interface, wired explicitly via `HensuFactory.builder().agentProviders(...)`.
-
-### Module Structure
-
-```
-hensu-core                    # Core workflow engine (pure Java, zero external deps)
-hensu-dsl                     # Kotlin DSL for workflow definitions
-hensu-serialization           # Jackson-based JSON serialization for workflow types (Node, TransitionRule, Action)
-hensu-cli                     # Quarkus-based CLI (PicoCLI) - compiles DSL, executes locally
-hensu-server                  # Quarkus-based server (native image) - receives JSON, executes via MCP
-hensu-langchain4j-adapter     # LangChain4j integration (Claude, GPT, Gemini, DeepSeek)
-```
-
-**Dependency flow**: `cli → dsl → core`, `cli → serialization → core`, `server → serialization → core`,
-`langchain4j-adapter → core`
-
-### Key Components
-
-**Entry Point**: `HensuFactory.builder()...build()` bootstraps everything:
-
-- `HensuEnvironment` - Container holding all core components (NEVER construct components directly)
-- `AgentFactory` - Creates agents from explicitly-wired providers
-- `AgentRegistry` / `DefaultAgentRegistry` - Manages agent instances
-- `WorkflowExecutor` - Executes workflow graphs
-- `NodeExecutorRegistry` - Registry for node type executors
-- `RubricEngine` - Evaluates output quality (rubrics embedded in workflow JSON)
-- `TemplateResolver` - Resolves `{placeholder}` syntax in prompts
-- `ReviewHandler` - Handles human review checkpoints (optional)
-- `ActionExecutor` - Executes workflow actions (CLI: local bash, Server: MCP-only)
-- `WorkflowRepository` - Tenant-scoped storage for workflow definitions (defaults to in-memory; JDBC impl in server)
-- `WorkflowStateRepository` - Tenant-scoped storage for execution state snapshots (defaults to in-memory; JDBC impl in server)
-- `ExecutionListener` - Lifecycle callbacks including `onCheckpoint(HensuState)` for inter-node persistence
-- `ProcessorPipeline` - Orchestrates pre/post node execution processor chains
-- `EngineVariables` - SSOT for engine-managed variable names (`score`, `approved`, `recommendation`)
-- `AgentLifecycleRunner` - Stateless agent call lifecycle (resolve → enrich → lookup → listener → execute → convert); shared by `StandardNodeExecutor` and `ParallelNodeExecutor`
-- `SynchronizedListenerDecorator` - Thread-safe `ExecutionListener` wrapper for parallel branch execution
-
-**Execution Lifecycle**: The `WorkflowExecutor` processes each node through a strict PRE-EXECUTE-POST pipeline.
-Pre-execution processors run in order: checkpoint → node start. Post-execution processors run in order: output
-extraction → node complete → history recording → human review → rubric evaluation → transition resolution. Any
-processor can short-circuit the pipeline by returning a terminal `ExecutionResult`. This design isolates cross-cutting
-concerns (e.g., adding a new rubric) from the core agent execution logic.
-
-**Server-Specific Components** (in `hensu-server`):
-
-- `HensuEnvironmentProducer` - CDI producer using HensuFactory.builder(); conditionally wires JDBC or in-memory repos
-- `ServerActionExecutor` - MCP-only action executor (rejects local execution)
-- `WorkflowResource` - REST API for workflow definitions (push/pull/delete/list)
-- `ExecutionResource` - REST API for execution runtime (start/resume/status/plan)
-- `JdbcWorkflowRepository` - PostgreSQL-backed workflow storage (plain class, not CDI bean)
-- `JdbcWorkflowStateRepository` - PostgreSQL-backed execution state storage (plain class, not CDI bean)
-- `ExecutionLeaseManager` - Distributed lease manager; generates `server_node_id`, bumps heartbeats, atomically claims stale executions (`@ApplicationScoped`)
-- `ExecutionHeartbeatJob` - Scheduled heartbeat; runs every `hensu.lease.heartbeat-interval` (default 30s) (`@ApplicationScoped`)
-- `WorkflowRecoveryJob` - Scheduled sweeper; claims orphaned executions older than `hensu.lease.stale-threshold` (default 90s) and resumes them (`@ApplicationScoped`)
-- `WorkflowRegistryService` - Push pipeline: wraps save in `WorkflowPushLock` and invokes `SubWorkflowGraphValidator` lazily resolving sub-workflow ids through the repository; rejects cycles and dangling refs before any row is written (`@ApplicationScoped`)
-- `WorkflowPushLock` - Cluster-wide push mutex (`pg_advisory_xact_lock` with JVM `ReentrantLock` fallback) so two concurrent pushes on different nodes cannot together introduce a cycle (`@ApplicationScoped`)
-
-**AI Provider Interface**:
-
-- `AgentProvider` interface in `io.hensu.core.agent`
-- Providers wired explicitly via `HensuFactory.builder().agentProviders(...)` — no classpath scanning, GraalVM-safe
-- Priority system: higher `getPriority()` wins when multiple providers support same model
-- `StubAgentProvider` (priority 1000) always auto-included by `build()` for testing
-
-### Data Model
-
-**Workflow Structure** (immutable, builder pattern):
-
-```
-Workflow
-├── agents: Map<String, AgentConfig>
-├── rubrics: Map<String, String>
-├── nodes: Map<String, Node>
-└── startNode: String
-```
-
-**Node Types**:
-
-- `StandardNode` - Regular step with agent execution, typed state variable output (`writes`), and transitions
-- `LoopNode` - Iterative execution with break conditions
-- `ParallelNode` - Concurrent execution with consensus; branches declare domain output via `yields()`
-- `ForkNode` - Spawn parallel execution paths
-- `JoinNode` - Await and merge forked paths
-- `GenericNode` - Custom execution logic via registered handlers
-- `ActionNode` - Execute commands mid-workflow (git, deploy, notify)
-- `EndNode` - Workflow termination (SUCCESS/FAILURE/CANCELLED)
-- `SubWorkflowNode` - Delegation to another workflow by id with input/output mapping; cycle + dangling-ref validation at push (`SubWorkflowGraphValidator`); depth cap `MAX_DEPTH = 16`; tenant isolation preserved via `_tenant_id` propagation
-
-**Transitions** (`TransitionRule` interface):
-
-- `SuccessTransition` / `FailureTransition` - Based on execution result
-- `ScoreTransition` - Conditional on rubric score (e.g., score >= 80 → approve)
-- `ApprovalTransition` - Routes on the `approved` boolean engine variable (injected by `ApprovalVariableInjector`); falls through if absent or non-boolean
-- `AlwaysTransition` - Unconditional
-
-### State Schema
-
-`WorkflowStateSchema` is an optional typed declaration on a `Workflow` that lists all domain-specific state variables:
-
-- `StateVariableDeclaration(name, type, isInput)` — declares one variable. Inputs are expected in the initial context; outputs are produced by nodes via `writes`.
-- `VarType` — `STRING`, `NUMBER`, `BOOLEAN`, `LIST_STRING`
-- **Engine variables** (`score`, `approved`) are always implicitly valid — never declare them in the schema.
-
-`WorkflowValidator` is called by `WorkflowBuilder.build()` and throws `IllegalStateException` listing all violations when:
-- A node's `writes` list contains a name not in the schema
-- A prompt `{variable}` reference is not in the schema
-
-Workflows without a schema operate in **legacy mode** (no load-time validation; outputs keyed by node ID).
-
-**DSL** (`state { }` block in `WorkflowBuilder`):
-```kotlin
-state {
-    input("topic", VarType.STRING)
-    variable("article", VarType.STRING)
-    variable("approved", VarType.BOOLEAN)   // NOT needed — engine variable, shown for clarity only
-}
-```
-
-### State Model
-
-Execution state flows through three types:
-
-- `HensuState` — Mutable runtime state during execution. Holds `executionId`, `workflowId`, `currentNode`, `context`
-  (Map), and `ExecutionHistory`. Created by `WorkflowExecutor` at execution start; mutated during node transitions.
-- `HensuSnapshot` — Immutable checkpoint record. Created from `HensuState.toSnapshot()` at pause points and completion.
-  Stored in `WorkflowStateRepository`. Contains `checkpointReason` ("paused", "completed", etc.).
-- `ExecutionHistory` — Tracks executed steps and backtracks. Its `copy()` returns mutable copies (not `List.copyOf()`)
-  so resumed executions can continue appending steps.
-
-**Checkpoint lifecycle** (inter-node persistence for failover):
-
-1. `CheckpointPreProcessor` fires `listener.onCheckpoint(state)` as the first step before each non-end node
-2. `WorkflowService` implements `ExecutionListener.onCheckpoint()` to save a `HensuSnapshot` with reason `"checkpoint"`
-3. If server dies mid-execution → restart → `findPaused()` returns interrupted executions → resume from last checkpoint
-
-**Pause / Resume lifecycle:**
-
-1. Node returns `ResultStatus.PENDING` → `WorkflowExecutor` returns `ExecutionResult.Paused(state)`
-2. `WorkflowService` saves snapshot with reason `"paused"`
-3. Later: `WorkflowService.resumeExecution()` loads snapshot → restores `HensuState` → calls
-   `WorkflowExecutor.executeFrom()` → saves final snapshot
-
-**Distributed Recovery & Leasing:**
-
-Each `HensuSnapshot` with `checkpointReason = "checkpoint"` is tied to a server lease via two
-columns in `hensu.execution_states`:
-
-- `server_node_id` — set to the owning server's UUID on `save("checkpoint")`; cleared to `NULL`
-  on `"completed"`, `"paused"`, `"failed"`, or `"rejected"`
-- `last_heartbeat_at` — bumped every `hensu.lease.heartbeat-interval` (default 30s) by
-  `ExecutionHeartbeatJob`
-
-`WorkflowRecoveryJob` periodically scans for rows where
-`last_heartbeat_at < NOW() - stale-threshold` (default 90s) and atomically claims them via a
-single `UPDATE … RETURNING` statement (safe under PostgreSQL `READ COMMITTED`). Claimed
-executions are immediately passed to `WorkflowService.resumeExecution()` on the surviving node.
-
-`findPaused()` filters `WHERE server_node_id IS NULL` — human-review checkpoints never appear in
-the recovery sweeper's scope.
-
-**Key context keys** (set by `WorkflowService.startExecution()`):
-
-- `_tenant_id` — tenant identifier, read by `SubWorkflowNodeExecutor` for loading child workflows
-- `_execution_id` — ensures `WorkflowExecutor` uses the same ID the service layer tracks
-- `_sub_workflow_depth` — recursion depth counter enforced by `SubWorkflowNodeExecutor.MAX_DEPTH = 16`
-
-### Patterns & Conventions
+## Patterns & Conventions
 
 1. **Builder pattern** for all domain models: `Workflow.builder().id(...).build()`
-2. **Constructor injection** - No @Autowired, explicit dependency wiring
+2. **Constructor injection** — no `@Autowired`, explicit dependency wiring
 3. **Sealed interfaces** for results: `ExecutionResult` → `Completed | Paused | Rejected | Failure | Success`
 4. **Template resolution**: `{variable}` syntax in prompts, resolved via `SimpleTemplateResolver`
-5. **@DslMarker** on Kotlin builders to prevent scope leakage
+5. **`@DslMarker`** on Kotlin builders to prevent scope leakage
 
-### Kotlin DSL
+## Key Architectural Rules
 
-Workflows defined in `.kt` files parsed by `KotlinScriptParser`:
+1. **HensuFactory pattern**: ALWAYS use `HensuFactory.builder()` — never construct core components directly.
+2. **Client-side compilation**: CLI compiles Kotlin DSL → JSON; server receives pre-compiled JSON (no Kotlin compiler in native image).
+3. **Build-then-push**: `hensu build` compiles to `{working-dir}/build/`; `hensu push` reads compiled JSON (no recompilation).
+4. **Shared serialization**: CLI and server both use `hensu-serialization`; `WorkflowSerializer.createMapper()` is the single `ObjectMapper` factory.
+5. **Server MCP-only**: server never executes bash locally, only MCP requests to external tools.
+6. **Storage in core**: repository interfaces and in-memory defaults live in `hensu-core`. JDBC impls live in `hensu-server/persistence/` as plain classes (not CDI beans). `HensuEnvironmentProducer` conditionally wires JDBC vs in-memory. Server exposes core components via `@Produces @Singleton` — never instantiates directly.
+7. **API separation**: `/api/v1/workflows` (definitions) and `/api/v1/executions` (runtime) are distinct resources.
+8. **JWT authentication**: SmallRye JWT bearer auth. Tenant identity extracted from `tenant_id` claim via `RequestTenantResolver`. CLI sends `Authorization: Bearer <token>` via `--token` or `hensu.server.token` config. Dev/test mode disables auth (`hensu.tenant.default`). RSA keys live outside the repo (e.g. `~/.hensu/`).
 
-```kotlin
-workflow("example") {
-    agents {
-        agent("writer") { model = Models.CLAUDE_SONNET_4_5 }
-    }
-    graph {
-        start at "write"
+## CLI
 
-        node("write") {
-            agent = "writer"
-            prompt = "Write about {topic}"
-            onSuccess goto "end"
-        }
+Verbs: `run | validate | visualize | build | push | pull | delete | list`. Use `-h` for args. `build` compiles `.kt` → JSON in `{working-dir}/build/`; `push` reads compiled JSON by workflow ID (not the `.kt`).
 
-        end("end")
-    }
-}
-```
+Example workflows: `working-dir/workflows/*.kt`.
 
-### Environment Variables
+## Environment Variables
 
-Credentials loaded via `HensuFactory.loadCredentialsFromEnvironment()`:
-
-- `ANTHROPIC_API_KEY` - Claude models
-- `OPENAI_API_KEY` - GPT models
-- `GOOGLE_API_KEY` - Gemini models
-- `DEEPSEEK_API_KEY` - DeepSeek models
-- `OPENROUTER_API_KEY`, `AZURE_OPENAI_KEY`
-
-### CLI Commands
-
-```bash
-# Local execution
-./hensu run -d working-dir workflow.kt                    # Execute workflow locally
-./hensu run -d working-dir workflow.kt -v                 # Execute with verbose output
-./hensu validate -d working-dir workflow.kt               # Validate syntax
-./hensu visualize -d working-dir workflow.kt              # Visualize as ASCII text
-./hensu visualize -d working-dir workflow.kt --format mermaid  # Visualize as Mermaid diagram
-
-# Build (compile DSL → JSON)
-./hensu build workflow.kt -d working-dir                  # Compile to working-dir/build/{id}.json
-
-# Server workflow management (terraform/kubectl pattern)
-./hensu push <workflow-id> --server http://host:8080      # Push compiled JSON to server
-./hensu pull <workflow-id>                                 # Pull workflow definition from server
-./hensu delete <workflow-id>                               # Delete workflow from server
-./hensu list                                              # List all workflows on server
-```
-
-**Build-then-push workflow**: `build` compiles Kotlin DSL → JSON in `{working-dir}/build/`. `push` reads the compiled
-JSON by workflow ID (not the .kt file).
-
-### Key Architectural Rules
-
-1. **HensuFactory pattern**: ALWAYS use `HensuFactory.builder()` - never construct core components directly
-2. **Client-side compilation**: CLI compiles Kotlin DSL → JSON; server receives pre-compiled JSON (no Kotlin compiler in
-   native image)
-3. **Build-then-push**: `hensu build` compiles to `{working-dir}/build/`; `hensu push` reads compiled JSON (no
-   recompilation)
-4. **Shared serialization**: Both CLI and server use `hensu-serialization` for JSON format —
-   `WorkflowSerializer.createMapper()` is the single ObjectMapper factory
-5. **Server MCP-only**: Server never executes bash commands locally, only sends MCP requests to external tools
-6. **Storage in core**: Repository interfaces (`WorkflowRepository`, `WorkflowStateRepository`) and in-memory defaults
-   live in `hensu-core`. JDBC implementations live in `hensu-server/persistence/` as plain classes (not CDI beans).
-   `HensuEnvironmentProducer` conditionally creates JDBC repos when DataSource is available, otherwise falls back to
-   in-memory. Server delegates from `HensuEnvironment` via `@Produces @Singleton` — never creates instances directly
-7. **API separation**: Workflow definitions (`/api/v1/workflows`) and executions (`/api/v1/executions`) are distinct
-   REST resources
-8. **JWT authentication**: Server uses SmallRye JWT (`quarkus-smallrye-jwt`) for bearer token auth. Tenant identity
-   is extracted from the `tenant_id` claim via `RequestTenantResolver`. CLI sends `Authorization: Bearer <token>`
-   header via `--token` option or `hensu.server.token` config. In dev/test mode, auth is disabled and a default tenant
-   is used (`hensu.tenant.default`). RSA keys are stored externally (e.g., `~/.hensu/`), never in the repository.
+Provider credentials loaded via `HensuFactory.loadCredentialsFromEnvironment()`: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`, `DEEPSEEK_API_KEY`, `OPENROUTER_API_KEY`, `AZURE_OPENAI_KEY`.
 
 ## Testing
 
-- JUnit 5 + AssertJ + Mockito
-- Stub mode for testing without API calls: `HENSU_STUB_ENABLED=true`
-- Mock agents for unit testing
-- Core module testable in complete isolation (no AI dependencies)
-
-### Integration Tests (`hensu-server`)
-
-**Integration tests** extend `IntegrationTestBase` and run under `@QuarkusTest` with `@TestProfile(InMemoryTestProfile.class)`.
-The `inmem` profile disables PostgreSQL (no Docker required). The base class provides:
-
-- `loadWorkflow("fixture.json")` — Loads a JSON fixture from `test/resources/workflows/`
-- `registerStub("nodeId", "response")` — Registers a programmatic stub response
-- `registerStub("scenario", "nodeId", "response")` — Registers a scenario-specific stub
-- `pushAndExecute(workflow, context)` — Saves workflow to repository and executes via `WorkflowService`
-- `pushAndExecuteWithMcp(workflow, context, endpoint)` — Same but within a `TenantContext` with MCP endpoint
-- `resolveRubricPath("quality.md")` — Copies a classpath rubric to a temp file (required by `RubricParser`)
-
-Per-test cleanup (`@BeforeEach`): clears `StubResponseRegistry`, deletes all tenant data via
-`WorkflowStateRepository.deleteAllForTenant()` and `WorkflowRepository.deleteAllForTenant()` (execution states first
-due to FK constraint).
-
-**Test handlers** (`@ApplicationScoped` beans auto-discovered by Quarkus):
-
-- `TestActionHandler` — `GenericNodeHandler` for `type="test-action"`, captures invocations
-- `TestReviewHandler` — Configurable `ReviewHandler` returning approve/reject/backtrack
-- `TestPauseHandler` — `GenericNodeHandler` for `type="pause"`, returns PENDING on first call, SUCCESS on second
-- `TestValidatorHandler` — `GenericNodeHandler` for `type="test-validator"`, validates context keys
-
-**Stub resolution order**: programmatic → `/stubs/{scenario}/{nodeId}.txt` → `/stubs/default/{nodeId}.txt` → echo
-fallback.
-
-**Repository tests** (`io.hensu.server.persistence`) use plain JUnit 5 + Testcontainers PostgreSQL (no Quarkus context).
-`JdbcRepositoryTestBase` starts a PostgreSQL container, runs Flyway migrations, and provides a DataSource. Tests verify
-CRUD operations, UPSERT semantics, FK constraints, tenant isolation, and serialization round-trips.
-
-## Key Files to Understand
-
-**Core:**
-
-- `hensu-core/.../HensuFactory.java` - Bootstrap and environment creation
-- `hensu-core/.../HensuEnvironment.java` - Container for all core components
-- `hensu-core/.../agent/AgentFactory.java` - Creates agents from explicit providers
-- `hensu-core/.../execution/WorkflowExecutor.java` - Main execution engine
-- `hensu-core/.../execution/pipeline/ProcessorPipeline.java` - Pre/post processor orchestration
-- `hensu-core/.../execution/pipeline/ProcessorContext.java` - Per-iteration context carrier
-- `hensu-core/.../workflow/Workflow.java` - Core data model
-- `hensu-core/.../rubric/RubricEngine.java` - Quality evaluation engine
-- `hensu-core/.../tool/ToolRegistry.java` - Protocol-agnostic tool descriptors
-- `hensu-core/.../plan/PlanPipeline.java` - Executes ordered `PlanProcessor` chains (preparation + execution)
-- `hensu-core/.../plan/PlanContext.java` - Mutable state carrier flowing through both plan pipelines
-- `hensu-core/.../plan/PlanExecutor.java` - Iterates plan steps via `StepHandlerRegistry`
-- `hensu-core/.../plan/StepHandlerRegistry.java` - Dispatches `PlanStepAction` to registered `StepHandler` instances
-- `hensu-core/.../plan/StaticPlanner.java` - Resolves predefined DSL `plan { }` steps (`STATIC` mode)
-- `hensu-core/.../plan/LlmPlanner.java` - Generates and revises plans via LLM agent (`DYNAMIC` mode)
-- `hensu-core/.../execution/executor/AgenticNodeExecutor.java` - Drives the two-pipeline plan flow for `StandardNode`
-- `hensu-core/.../workflow/WorkflowRepository.java` - Tenant-scoped workflow storage interface
-- `hensu-core/.../state/WorkflowStateRepository.java` - Tenant-scoped execution state storage interface
-- `hensu-core/.../workflow/state/WorkflowStateSchema.java` - Typed state variable schema (optional per-workflow declaration)
-- `hensu-core/.../workflow/state/StateVariableDeclaration.java` - Single variable declaration (name, type, isInput)
-- `hensu-core/.../workflow/state/VarType.java` - Variable type enum (STRING, NUMBER, BOOLEAN, LIST_STRING)
-- `hensu-core/.../execution/EngineVariables.java` - SSOT for engine-managed variable names (score, approved, recommendation)
-- `hensu-core/.../execution/SynchronizedListenerDecorator.java` - Thread-safe listener wrapper for parallel branches
-- `hensu-core/.../execution/executor/AgentLifecycleRunner.java` - Shared agent call lifecycle (resolve → enrich → execute)
-- `hensu-core/.../execution/parallel/BranchExecutionConfig.java` - Per-branch config carried on ExecutionContext
-- `hensu-core/.../execution/enricher/YieldsVariableInjector.java` - Injects yield format instructions for branch prompts
-- `hensu-core/.../workflow/transition/ApprovalTransition.java` - Boolean approval routing via `approved` engine variable
-- `hensu-core/.../workflow/validation/WorkflowValidator.java` - Load-time validator for `writes` and prompt variable references
-- `hensu-core/.../workflow/validation/SubWorkflowGraphValidator.java` - Cycle + dangling-ref detection across the sub-workflow reference graph (single DFS, `globallyVisited`); CLI overload `validate(Collection<Workflow>)` for local cycle-only checks, server overload `validate(Workflow, Function<String,Workflow>)` for push with lazy repository resolution
-- `hensu-core/.../execution/executor/SubWorkflowNodeExecutor.java` - Child workflow execution with `MAX_DEPTH = 16` recursion cap and `_tenant_id` propagation
-
-**DSL:**
-
-- `hensu-dsl/.../dsl/HensuDSL.kt` - DSL entry point (`workflow()` function)
-- `hensu-dsl/.../dsl/parsers/KotlinScriptParser.kt` - Script compilation
-- `hensu-dsl/.../dsl/builders/GraphBuilder.kt` - Graph DSL (node, action, end, etc.)
-- `hensu-dsl/.../dsl/builders/StateSchemaBuilder.kt` - `state { }` DSL block builder (input/variable declarations)
-
-**Serialization:**
-
-- `hensu-serialization/.../WorkflowSerializer.java` - Entry point: `toJson()`, `fromJson()`, `createMapper()`
-- `hensu-serialization/.../HensuJacksonModule.java` - Jackson module registering all custom ser/deser
-- `hensu-serialization/.../NodeSerializer.java` / `NodeDeserializer.java` - Node type hierarchy
-- `hensu-serialization/.../TransitionRuleSerializer.java` / `TransitionRuleDeserializer.java` - Transition rules
-- `hensu-serialization/.../ActionSerializer.java` / `ActionDeserializer.java` - Action types
-- `hensu-serialization/.../mixin/` - Jackson mixins for builder-based deserialization (Workflow, AgentConfig)
-
-**Server:**
-
-- `hensu-server/.../config/HensuEnvironmentProducer.java` - CDI producer (HensuFactory → HensuEnvironment); conditional JDBC/in-memory wiring
-- `hensu-server/.../config/ServerConfiguration.java` - CDI delegation + server beans (ObjectMapper via
-  `WorkflowSerializer.createMapper()`)
-- `hensu-server/.../action/ServerActionExecutor.java` - MCP-only action executor
-- `hensu-server/.../api/WorkflowResource.java` - Workflow definition management REST API
-- `hensu-server/.../api/ExecutionResource.java` - Execution runtime REST API
-- `hensu-server/.../persistence/JdbcWorkflowRepository.java` - PostgreSQL workflow storage (plain JDBC, JSONB)
-- `hensu-server/.../persistence/JdbcWorkflowStateRepository.java` - PostgreSQL execution state storage (plain JDBC, JSONB)
-- `hensu-server/src/main/resources/db/migration/V1__create_persistence_tables.sql` - Flyway schema migration
-- `hensu-server/src/main/resources/db/migration/V2__add_execution_leases.sql` - Lease columns migration
-- `hensu-server/.../persistence/ExecutionLeaseManager.java` - Distributed lease manager (heartbeat + atomic claim)
-- `hensu-server/.../persistence/WorkflowPushLock.java` - Cluster-wide push mutex (pg_advisory_xact_lock + JVM fallback)
-- `hensu-server/.../workflow/ExecutionHeartbeatJob.java` - Heartbeat emission (@Scheduled)
-- `hensu-server/.../workflow/WorkflowRecoveryJob.java` - Recovery sweeper (@Scheduled)
-- `hensu-server/.../workflow/WorkflowRegistryService.java` - Push pipeline: `WorkflowPushLock` + `SubWorkflowGraphValidator`
-
-**CLI:**
-
-- `hensu-cli/.../commands/HensuCLI.java` - Top-level command registration
-- `hensu-cli/.../commands/WorkflowBuildCommand.java` - Compile DSL → JSON (`hensu build`)
-- `hensu-cli/.../commands/WorkflowPushCommand.java` - Push compiled JSON to server (`hensu push`)
-- `hensu-cli/.../commands/ServerCommand.java` - Base class for server-interacting commands (HTTP client,
-  --server/--token options, JWT bearer authentication)
-
-**Examples:**
-
-- `working-dir/workflows/*.kt` - Example workflows
+- JUnit 5 + AssertJ + Mockito. Stub mode: `HENSU_STUB_ENABLED=true`. Core testable in isolation (no AI deps).
+- **Integration tests** (`hensu-server`): extend `IntegrationTestBase`, run under `@QuarkusTest` with `@TestProfile(InMemoryTestProfile.class)`. The `inmem` profile disables PostgreSQL (no Docker). Base class provides `loadWorkflow`, `registerStub`, `pushAndExecute`, `pushAndExecuteWithMcp`, `resolveRubricPath`. Per-test cleanup clears `StubResponseRegistry` and deletes tenant data (execution states first, FK constraint).
+- **Test handlers** (auto-discovered `@ApplicationScoped`): `TestActionHandler`, `TestReviewHandler`, `TestPauseHandler`, `TestValidatorHandler`.
+- **Stub resolution order**: programmatic → `/stubs/{scenario}/{nodeId}.txt` → `/stubs/default/{nodeId}.txt` → echo fallback.
+- **Repository tests** (`io.hensu.server.persistence`): plain JUnit 5 + Testcontainers PostgreSQL (no Quarkus). `JdbcRepositoryTestBase` starts container, runs Flyway, provides `DataSource`.


### PR DESCRIPTION
…i MC

Split monolithic rules into always-on invariants vs task-triggered skills so session context stays lean. Mirror under .cursor/rules/ for parity.

Rules
- Add 02-output-density.md (dense chat, prose for artifacts).
- Tighten 01-model-coordination.md: dual/single-model auto-detect, pinned.

Gemini model IDs, discovery prohibition.
- Slim 10-java-standards.md and 20-native-safety.md to invariants only; procedural detail moves into skills.

Skills (on demand)
- native-image-check, javadoc, visual-style.

Commands
- /assess-claude, /assess-gemini, /test-audit — Gemini-mediated review loops.

MCP
- Add project-scoped .mcp.json (gemini-cli via npx) and .mcp.README.md.
- Ignore .mcp.local.json and .claude/tmp/.

AGENTS.md
- Collapse to a terse index pointing at docs/; avoids drift from sources.